### PR TITLE
Improve large-workbook handling and frozen-pane rendering in the XLSX viewer

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -8,6 +8,8 @@ import {
   XlsxViewer,
   XlsxViewerProvider
 } from "react-xlsx";
+
+const AUTO_READ_ONLY_THRESHOLD_BYTES = 5 * 1024 * 1024;
 import {
   ChevronLeft,
   ChevronRight,
@@ -431,10 +433,10 @@ export function App() {
 
   const controller = useXlsxViewerController(
     source?.type === "file"
-      ? { file: source.file, fileName: source.fileName, readOnly: isReadOnly }
+      ? { file: source.file, fileName: source.fileName, readOnly: isReadOnly, readOnlyAboveBytes: AUTO_READ_ONLY_THRESHOLD_BYTES }
       : source?.type === "url"
-        ? { src: source.src, fileName: source.fileName, readOnly: isReadOnly }
-        : { readOnly: isReadOnly }
+        ? { src: source.src, fileName: source.fileName, readOnly: isReadOnly, readOnlyAboveBytes: AUTO_READ_ONLY_THRESHOLD_BYTES }
+        : { readOnly: isReadOnly, readOnlyAboveBytes: AUTO_READ_ONLY_THRESHOLD_BYTES }
   );
 
   const loadWorkbookFile = React.useCallback(async (nextFile: File) => {

--- a/packages/react-xlsx/package.json
+++ b/packages/react-xlsx/package.json
@@ -29,7 +29,7 @@
     "fflate": "^0.8.2"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --sourcemap --clean --external react,react-dom",
+    "build": "tsup src/index.ts --format esm,cjs --dts --sourcemap --clean --external react,react-dom && tsup src/xlsx-worker.ts --format esm --sourcemap --clean false --out-dir dist",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "clean": "rm -rf dist"
   }

--- a/packages/react-xlsx/src/XlsxViewer.tsx
+++ b/packages/react-xlsx/src/XlsxViewer.tsx
@@ -42,6 +42,12 @@ const MIN_OPEN_GRID_ROWS = 200;
 const MIN_OPEN_GRID_COLS = 50;
 const OPEN_GRID_ROW_PADDING = 120;
 const OPEN_GRID_COL_PADDING = 24;
+const INITIAL_WORKER_GRID_ROWS = 600;
+const INITIAL_WORKER_GRID_COLS = 120;
+const WORKER_GRID_GROW_ROWS = 2000;
+const WORKER_GRID_GROW_COLS = 120;
+const WORKER_GRID_GROW_THRESHOLD_ROWS = 160;
+const WORKER_GRID_GROW_THRESHOLD_COLS = 24;
 const OPEN_GRID_ROW_GROWTH = 200;
 const OPEN_GRID_COL_GROWTH = 24;
 const OPEN_GRID_VERTICAL_EDGE_PX = 600;
@@ -317,6 +323,49 @@ function resolveOpenGridExtent(maxUsedIndex: number, minimum: number, padding: n
   return Math.max(maxUsedIndex + 1 + padding, minimum);
 }
 
+function buildVisibleAxisIndices(
+  precomputed: number[],
+  displayLimit: number,
+  maxUsedIndex: number,
+  hiddenIndices?: Set<number>
+) {
+  if (displayLimit <= 0) {
+    return [];
+  }
+
+  if (precomputed.length === 0) {
+    const visible: number[] = [];
+    const usedLimit = Math.min(displayLimit, Math.max(0, maxUsedIndex + 1));
+    for (let index = 0; index < usedLimit; index += 1) {
+      if (!hiddenIndices?.has(index)) {
+        visible.push(index);
+      }
+    }
+    for (let index = usedLimit; index < displayLimit; index += 1) {
+      visible.push(index);
+    }
+    return visible;
+  }
+
+  const visible = precomputed.filter((value) => value < displayLimit);
+  const appendStart = Math.max(0, maxUsedIndex + 1);
+  for (let index = appendStart; index < displayLimit; index += 1) {
+    visible.push(index);
+  }
+  return visible;
+}
+
+function resolveInitialDisplayExtent(
+  maxUsedIndex: number,
+  minimum: number,
+  padding: number,
+  isWorkerBacked: boolean,
+  initialCap: number
+) {
+  const fullExtent = resolveOpenGridExtent(maxUsedIndex, minimum, padding);
+  return isWorkerBacked ? Math.min(fullExtent, Math.max(minimum, initialCap)) : fullExtent;
+}
+
 function sumBeforeActualIndex(actualIndices: number[], sizes: number[], actualIndex: number) {
   let total = 0;
   for (let index = 0; index < actualIndices.length; index += 1) {
@@ -453,6 +502,28 @@ function resolveImageAnchorExtents(image: XlsxImage) {
   };
 }
 
+function resolveAnchoredBounds(anchor: XlsxImage["anchor"] | XlsxShape["anchor"]) {
+  if (anchor.kind === "absolute") {
+    return null;
+  }
+
+  if (anchor.kind === "one-cell") {
+    return {
+      maxCol: anchor.from.col,
+      maxRow: anchor.from.row,
+      minCol: anchor.from.col,
+      minRow: anchor.from.row
+    };
+  }
+
+  return {
+    maxCol: Math.max(anchor.from.col, anchor.to.col),
+    maxRow: Math.max(anchor.from.row, anchor.to.row),
+    minCol: Math.min(anchor.from.col, anchor.to.col),
+    minRow: Math.min(anchor.from.row, anchor.to.row)
+  };
+}
+
 function resolveShapeAnchorExtents(shape: XlsxShape) {
   if (shape.anchor.kind === "absolute") {
     return { maxCol: 0, maxRow: 0 };
@@ -468,6 +539,37 @@ function resolveShapeAnchorExtents(shape: XlsxShape) {
   return {
     maxCol: Math.max(shape.anchor.from.col, shape.anchor.to.col),
     maxRow: Math.max(shape.anchor.from.row, shape.anchor.to.row)
+  };
+}
+
+function resolveFrozenDrawingOffsets(
+  anchor: XlsxImage["anchor"] | XlsxShape["anchor"],
+  freezePanes: XlsxSheetData["freezePanes"] | null,
+  stickyTopByRow: Map<number, number>,
+  stickyLeftByCol: Map<number, number>,
+  scrollTop: number,
+  scrollLeft: number
+) {
+  const bounds = resolveAnchoredBounds(anchor);
+  if (!bounds) {
+    return {
+      left: undefined,
+      top: undefined
+    };
+  }
+
+  const top =
+    freezePanes?.row && freezePanes.row > 0 && bounds.maxRow < freezePanes.row
+      ? (stickyTopByRow.get(bounds.minRow) ?? 0) + scrollTop
+      : undefined;
+  const left =
+    freezePanes?.col && freezePanes.col > 0 && bounds.maxCol < freezePanes.col
+      ? (stickyLeftByCol.get(bounds.minCol) ?? 0) + scrollLeft
+      : undefined;
+
+  return {
+    left,
+    top
   };
 }
 
@@ -1057,6 +1159,17 @@ function resolveSpreadsheetLineHeight(fontSizePt?: number) {
   return 1.3;
 }
 
+function buildGridlineShadow(color: string, options?: { bottom?: boolean; right?: boolean }) {
+  const parts: string[] = [];
+  if (options?.right !== false) {
+    parts.push(`inset -1px 0 0 ${color}`);
+  }
+  if (options?.bottom !== false) {
+    parts.push(`inset 0 -1px 0 ${color}`);
+  }
+  return parts.join(", ");
+}
+
 function buildCellStyle(
   style: Record<string, unknown> | null | undefined,
   palette: ViewerPalette,
@@ -1067,10 +1180,12 @@ function buildCellStyle(
   const baseSurface = paletteIsDark(palette)
     ? resolveDarkModeSurface(themePalette, palette)
     : themePalette?.colorsByIndex[0] ?? SHEET_SURFACE;
+  const gridlineShadow = showGridLines ? buildGridlineShadow(palette.border) : undefined;
   const css: React.CSSProperties = {
     backgroundColor: baseSurface,
-    borderBottom: showGridLines ? `1px solid ${SHEET_GRIDLINE}` : "none",
-    borderRight: showGridLines ? `1px solid ${SHEET_GRIDLINE}` : "none",
+    borderBottom: "none",
+    borderRight: "none",
+    boxShadow: gridlineShadow,
     color: resolveReadableTextColor(null, baseSurface, palette),
     fontFamily: buildSpreadsheetFontFamily({ scheme: "minor" }, themePalette) ?? "\"Segoe UI\", Tahoma, Arial, sans-serif",
     fontSize: "12px",
@@ -1163,6 +1278,14 @@ function buildCellStyle(
 
   const border = style.border as Record<string, Record<string, unknown>> | undefined;
   if (border) {
+    const hasRightBorder = Boolean(border.right?.style && border.right.style !== "none");
+    const hasBottomBorder = Boolean(border.bottom?.style && border.bottom.style !== "none");
+    if (showGridLines && (hasRightBorder || hasBottomBorder)) {
+      css.boxShadow = buildGridlineShadow(palette.border, {
+        bottom: !hasBottomBorder,
+        right: !hasRightBorder
+      }) || undefined;
+    }
     if (border.top?.style && border.top.style !== "none") {
       css.borderTop = mapBorder(border.top as { style: string; color?: Record<string, unknown> }, themePalette);
     }
@@ -1351,6 +1474,47 @@ function normalizeBatchedCellValue(
   }
 
   return value;
+}
+
+function buildWorksheetBatchWindow(
+  rows: unknown[] | null,
+  activeSheet: XlsxSheetData | null,
+  startRow: number,
+  endRow: number
+): WorksheetBatchWindow {
+  const cells = new Map<string, BatchedCellData>();
+
+  if (Array.isArray(rows)) {
+    for (const rowEntry of rows as WorksheetBatchRowEntry[]) {
+      const row = asNonNegativeInteger(rowEntry.index);
+      if (row === null || !Array.isArray(rowEntry.cells)) {
+        continue;
+      }
+
+      for (const cellEntry of rowEntry.cells as WorksheetBatchCellEntry[]) {
+        const col = asNonNegativeInteger(cellEntry.col);
+        if (col === null) {
+          continue;
+        }
+
+        const formula = typeof cellEntry.formula === "string" ? cellEntry.formula : null;
+        cells.set(`${row}:${col}`, {
+          formula,
+          hyperlink: normalizeBatchedHyperlink(cellEntry.hyperlink),
+          isMergedSecondary: cellEntry.isMergedSecondary === true,
+          mergeSpan: normalizeBatchedMergeSpan(cellEntry.mergeSpan),
+          style: asRecord(cellEntry.style),
+          value: normalizeBatchedCellValue(cellEntry.value, formula, row, col, activeSheet)
+        });
+      }
+    }
+  }
+
+  return {
+    cells,
+    endRow,
+    startRow
+  };
 }
 
 function getTableAtCell(tables: XlsxTable[], row: number, col: number) {
@@ -2625,12 +2789,14 @@ function XlsxGrid({
     error,
     fillSelection,
     getActiveWorksheet,
+    getRowsBatchAsync,
     getClipboardData,
     getCellDisplayValue: getControllerCellDisplayValue,
     images,
     shapes,
     isLoadDeferred,
     isLoading,
+    isWorkerBacked,
     copySelectionToClipboard,
     pasteFromClipboard,
     pasteStructuredClipboardData,
@@ -2663,6 +2829,7 @@ function XlsxGrid({
   const rowElementRefs = React.useRef(new Map<number, HTMLTableRowElement>());
   const columnPreviewRef = React.useRef<{ actualIndex: number; size: number } | null>(null);
   const rowPreviewRef = React.useRef<{ actualIndex: number; size: number } | null>(null);
+  const [scrollPosition, setScrollPosition] = React.useState({ left: 0, top: 0 });
   const activeCellRef = React.useRef<XlsxCellAddress | null>(activeCell);
   const selectionRef = React.useRef<XlsxCellRange | null>(null);
   const editingCellRef = React.useRef<XlsxCellAddress | null>(null);
@@ -2753,29 +2920,41 @@ function XlsxGrid({
   const normalizedSelection = React.useMemo(() => (selection ? normalizeRange(selection) : null), [selection]);
   const effectiveTables = tables;
   const [displayRowLimit, setDisplayRowLimit] = React.useState(() =>
-    resolveOpenGridExtent(activeSheet?.maxUsedRow ?? -1, MIN_OPEN_GRID_ROWS, OPEN_GRID_ROW_PADDING)
+    resolveInitialDisplayExtent(
+      activeSheet?.maxUsedRow ?? -1,
+      MIN_OPEN_GRID_ROWS,
+      OPEN_GRID_ROW_PADDING,
+      Boolean(isWorkerBacked),
+      INITIAL_WORKER_GRID_ROWS
+    )
   );
   const [displayColLimit, setDisplayColLimit] = React.useState(() =>
-    resolveOpenGridExtent(activeSheet?.maxUsedCol ?? -1, MIN_OPEN_GRID_COLS, OPEN_GRID_COL_PADDING)
+    resolveInitialDisplayExtent(
+      activeSheet?.maxUsedCol ?? -1,
+      MIN_OPEN_GRID_COLS,
+      OPEN_GRID_COL_PADDING,
+      Boolean(isWorkerBacked),
+      INITIAL_WORKER_GRID_COLS
+    )
   );
+  const hiddenRowSet = React.useMemo(() => new Set(activeSheet?.hiddenRows ?? []), [activeSheet?.hiddenRows]);
+  const hiddenColSet = React.useMemo(() => new Set(activeSheet?.hiddenCols ?? []), [activeSheet?.hiddenCols]);
   const visibleRows = React.useMemo(() => {
-    const rows: number[] = [];
-    for (let row = 0; row < displayRowLimit; row += 1) {
-      if (!worksheet || !worksheet.isRowHidden(row)) {
-        rows.push(row);
-      }
-    }
-    return rows;
-  }, [displayRowLimit, revision, worksheet]);
+    return buildVisibleAxisIndices(
+      activeSheet?.visibleRows ?? [],
+      displayRowLimit,
+      activeSheet?.maxUsedRow ?? -1,
+      hiddenRowSet
+    );
+  }, [activeSheet?.maxUsedRow, activeSheet?.visibleRows, displayRowLimit, hiddenRowSet]);
   const visibleCols = React.useMemo(() => {
-    const cols: number[] = [];
-    for (let col = 0; col < displayColLimit; col += 1) {
-      if (!worksheet || !worksheet.isColumnHidden(col)) {
-        cols.push(col);
-      }
-    }
-    return cols;
-  }, [displayColLimit, revision, worksheet]);
+    return buildVisibleAxisIndices(
+      activeSheet?.visibleCols ?? [],
+      displayColLimit,
+      activeSheet?.maxUsedCol ?? -1,
+      hiddenColSet
+    );
+  }, [activeSheet?.maxUsedCol, activeSheet?.visibleCols, displayColLimit, hiddenColSet]);
   const frozenRows = React.useMemo(() => {
     const freezeRow = activeSheet?.freezePanes?.row ?? 0;
     if (freezeRow <= 0) {
@@ -2793,50 +2972,140 @@ function XlsxGrid({
     return visibleCols.filter((col) => col < freezeCol);
   }, [activeSheet?.freezePanes?.col, visibleCols]);
   const actualColWidths = React.useMemo(
-    () =>
-      Array.from({ length: displayColLimit }, (_, col) => {
-        if (worksheet?.isColumnHidden(col)) {
-          return 0;
-        }
+    () => {
+      const widths = new Array(displayColLimit).fill(0);
+      const showGridLines = activeSheet?.showGridLines ?? true;
+      const fallbackWidth = Math.max(
+        resolveRenderedSheetAxisPixels(activeSheet?.defaultColWidthPx ?? DEFAULT_COL_WIDTH, showGridLines),
+        DEFAULT_COL_WIDTH / 2
+      );
 
-        const width = worksheet?.getColumnWidth(col);
-        const showGridLines = activeSheet?.showGridLines ?? true;
-        if (width !== undefined && width !== null) {
-          return Math.max(
-            resolveRenderedSheetAxisPixels(resolveSheetColumnWidthPixels(width), showGridLines),
+      if (worksheet) {
+        for (let col = 0; col < displayColLimit; col += 1) {
+          if (worksheet.isColumnHidden(col)) {
+            continue;
+          }
+
+          const width = worksheet.getColumnWidth(col);
+          if (width !== undefined && width !== null) {
+            widths[col] = Math.max(
+              resolveRenderedSheetAxisPixels(resolveSheetColumnWidthPixels(width), showGridLines),
+              DEFAULT_COL_WIDTH / 2
+            );
+            continue;
+          }
+
+          widths[col] = Math.max(
+            resolveRenderedSheetAxisPixels(
+              activeSheet?.colWidthOverridesPx[col] ?? activeSheet?.defaultColWidthPx ?? DEFAULT_COL_WIDTH,
+              showGridLines
+            ),
             DEFAULT_COL_WIDTH / 2
           );
         }
 
-        return resolveRenderedSheetAxisPixels(
-          activeSheet?.colWidthOverridesPx[col] ?? activeSheet?.defaultColWidthPx ?? DEFAULT_COL_WIDTH,
-          showGridLines
-        );
-      }),
-    [activeSheet?.colWidthOverridesPx, activeSheet?.defaultColWidthPx, activeSheet?.showGridLines, displayColLimit, worksheet, revision]
-  );
-  const actualRowHeights = React.useMemo(
-    () =>
-      Array.from({ length: displayRowLimit }, (_, row) => {
-        if (worksheet?.isRowHidden(row)) {
-          return 0;
+        return widths;
+      }
+
+      const precomputedCols = activeSheet?.visibleCols ?? [];
+      const precomputedWidths = activeSheet?.colWidths ?? [];
+      for (let index = 0; index < precomputedCols.length; index += 1) {
+        const col = precomputedCols[index];
+        if (col === undefined || col >= displayColLimit) {
+          continue;
         }
 
-        const height = worksheet?.getRowHeight(row);
-        const showGridLines = activeSheet?.showGridLines ?? true;
-        if (height !== undefined && height !== null) {
-          return Math.max(
-            resolveRenderedSheetAxisPixels(resolveSheetRowHeightPixels(height), showGridLines),
+        widths[col] = Math.max(
+          resolveRenderedSheetAxisPixels(precomputedWidths[index] ?? activeSheet?.defaultColWidthPx ?? DEFAULT_COL_WIDTH, showGridLines),
+          DEFAULT_COL_WIDTH / 2
+        );
+      }
+
+      for (let col = Math.max(0, (activeSheet?.maxUsedCol ?? -1) + 1); col < displayColLimit; col += 1) {
+        widths[col] = fallbackWidth;
+      }
+
+      return widths;
+    },
+    [
+      activeSheet?.colWidthOverridesPx,
+      activeSheet?.colWidths,
+      activeSheet?.defaultColWidthPx,
+      activeSheet?.maxUsedCol,
+      activeSheet?.showGridLines,
+      activeSheet?.visibleCols,
+      displayColLimit,
+      worksheet,
+      revision
+    ]
+  );
+  const actualRowHeights = React.useMemo(
+    () => {
+      const heights = new Array(displayRowLimit).fill(0);
+      const showGridLines = activeSheet?.showGridLines ?? true;
+      const fallbackHeight = Math.max(
+        resolveRenderedSheetAxisPixels(activeSheet?.defaultRowHeightPx ?? DEFAULT_ROW_HEIGHT, showGridLines),
+        DEFAULT_ROW_HEIGHT / 1.5
+      );
+
+      if (worksheet) {
+        for (let row = 0; row < displayRowLimit; row += 1) {
+          if (worksheet.isRowHidden(row)) {
+            continue;
+          }
+
+          const height = worksheet.getRowHeight(row);
+          if (height !== undefined && height !== null) {
+            heights[row] = Math.max(
+              resolveRenderedSheetAxisPixels(resolveSheetRowHeightPixels(height), showGridLines),
+              DEFAULT_ROW_HEIGHT / 1.5
+            );
+            continue;
+          }
+
+          heights[row] = Math.max(
+            resolveRenderedSheetAxisPixels(
+              activeSheet?.rowHeightOverridesPx[row] ?? activeSheet?.defaultRowHeightPx ?? DEFAULT_ROW_HEIGHT,
+              showGridLines
+            ),
             DEFAULT_ROW_HEIGHT / 1.5
           );
         }
 
-        return resolveRenderedSheetAxisPixels(
-          activeSheet?.rowHeightOverridesPx[row] ?? activeSheet?.defaultRowHeightPx ?? DEFAULT_ROW_HEIGHT,
-          showGridLines
+        return heights;
+      }
+
+      const precomputedRows = activeSheet?.visibleRows ?? [];
+      const precomputedHeights = activeSheet?.rowHeights ?? [];
+      for (let index = 0; index < precomputedRows.length; index += 1) {
+        const row = precomputedRows[index];
+        if (row === undefined || row >= displayRowLimit) {
+          continue;
+        }
+
+        heights[row] = Math.max(
+          resolveRenderedSheetAxisPixels(precomputedHeights[index] ?? activeSheet?.defaultRowHeightPx ?? DEFAULT_ROW_HEIGHT, showGridLines),
+          DEFAULT_ROW_HEIGHT / 1.5
         );
-      }),
-    [activeSheet?.defaultRowHeightPx, activeSheet?.rowHeightOverridesPx, activeSheet?.showGridLines, displayRowLimit, worksheet, revision]
+      }
+
+      for (let row = Math.max(0, (activeSheet?.maxUsedRow ?? -1) + 1); row < displayRowLimit; row += 1) {
+        heights[row] = fallbackHeight;
+      }
+
+      return heights;
+    },
+    [
+      activeSheet?.defaultRowHeightPx,
+      activeSheet?.maxUsedRow,
+      activeSheet?.rowHeightOverridesPx,
+      activeSheet?.rowHeights,
+      activeSheet?.showGridLines,
+      activeSheet?.visibleRows,
+      displayRowLimit,
+      worksheet,
+      revision
+    ]
   );
   const effectiveColWidths = React.useMemo(
     () => visibleCols.map((col) => actualColWidths[col] ?? DEFAULT_COL_WIDTH),
@@ -2890,6 +3159,49 @@ function XlsxGrid({
     horizontal: true,
     overscan: 6
   });
+  const currentRowVirtualItems = rowVirtualizer.getVirtualItems();
+  const currentColVirtualItems = colVirtualizer.getVirtualItems();
+  const maxRowDisplayLimit = React.useMemo(
+    () => resolveOpenGridExtent(activeSheet?.maxUsedRow ?? -1, MIN_OPEN_GRID_ROWS, OPEN_GRID_ROW_PADDING),
+    [activeSheet?.maxUsedRow]
+  );
+  const maxColDisplayLimit = React.useMemo(
+    () => resolveOpenGridExtent(activeSheet?.maxUsedCol ?? -1, MIN_OPEN_GRID_COLS, OPEN_GRID_COL_PADDING),
+    [activeSheet?.maxUsedCol]
+  );
+
+  React.useEffect(() => {
+    if (!isWorkerBacked) {
+      return;
+    }
+
+    const lastVirtualRowIndex = currentRowVirtualItems[currentRowVirtualItems.length - 1]?.index ?? -1;
+    const lastVirtualColIndex = currentColVirtualItems[currentColVirtualItems.length - 1]?.index ?? -1;
+
+    if (
+      lastVirtualRowIndex >= visibleRows.length - WORKER_GRID_GROW_THRESHOLD_ROWS
+      && displayRowLimit < maxRowDisplayLimit
+    ) {
+      setDisplayRowLimit((current) => Math.min(maxRowDisplayLimit, current + WORKER_GRID_GROW_ROWS));
+    }
+
+    if (
+      lastVirtualColIndex >= visibleCols.length - WORKER_GRID_GROW_THRESHOLD_COLS
+      && displayColLimit < maxColDisplayLimit
+    ) {
+      setDisplayColLimit((current) => Math.min(maxColDisplayLimit, current + WORKER_GRID_GROW_COLS));
+    }
+  }, [
+    currentColVirtualItems,
+    currentRowVirtualItems,
+    displayColLimit,
+    displayRowLimit,
+    isWorkerBacked,
+    maxColDisplayLimit,
+    maxRowDisplayLimit,
+    visibleCols.length,
+    visibleRows.length
+  ]);
 
   React.useEffect(() => {
     activeCellRef.current = activeCell;
@@ -2932,9 +3244,25 @@ function XlsxGrid({
   }, [colPrefixSums, effectiveColWidths, effectiveRowHeights, rowPrefixSums, visibleCols, visibleRows]);
 
   React.useEffect(() => {
-    setDisplayRowLimit(resolveOpenGridExtent(activeSheet?.maxUsedRow ?? -1, MIN_OPEN_GRID_ROWS, OPEN_GRID_ROW_PADDING));
-    setDisplayColLimit(resolveOpenGridExtent(activeSheet?.maxUsedCol ?? -1, MIN_OPEN_GRID_COLS, OPEN_GRID_COL_PADDING));
-  }, [activeSheet?.maxUsedCol, activeSheet?.maxUsedRow, activeSheetIndex]);
+    setDisplayRowLimit(
+      resolveInitialDisplayExtent(
+        activeSheet?.maxUsedRow ?? -1,
+        MIN_OPEN_GRID_ROWS,
+        OPEN_GRID_ROW_PADDING,
+        Boolean(isWorkerBacked),
+        INITIAL_WORKER_GRID_ROWS
+      )
+    );
+    setDisplayColLimit(
+      resolveInitialDisplayExtent(
+        activeSheet?.maxUsedCol ?? -1,
+        MIN_OPEN_GRID_COLS,
+        OPEN_GRID_COL_PADDING,
+        Boolean(isWorkerBacked),
+        INITIAL_WORKER_GRID_COLS
+      )
+    );
+  }, [activeSheet?.maxUsedCol, activeSheet?.maxUsedRow, activeSheetIndex, isWorkerBacked]);
 
   React.useEffect(() => {
     const selectionEnd = normalizedSelection?.end;
@@ -2959,14 +3287,26 @@ function XlsxGrid({
       { maxCol: -1, maxRow: -1 }
     );
     const nextRowLimit = Math.max(
-      resolveOpenGridExtent(activeSheet?.maxUsedRow ?? -1, MIN_OPEN_GRID_ROWS, OPEN_GRID_ROW_PADDING),
+      resolveInitialDisplayExtent(
+        activeSheet?.maxUsedRow ?? -1,
+        MIN_OPEN_GRID_ROWS,
+        OPEN_GRID_ROW_PADDING,
+        false,
+        INITIAL_WORKER_GRID_ROWS
+      ),
       (activeCell?.row ?? -1) + OPEN_GRID_ROW_PADDING + 1,
       (selectionEnd?.row ?? -1) + OPEN_GRID_ROW_PADDING + 1,
       imageExtents.maxRow + OPEN_GRID_ROW_PADDING + 1,
       shapeExtents.maxRow + OPEN_GRID_ROW_PADDING + 1
     );
     const nextColLimit = Math.max(
-      resolveOpenGridExtent(activeSheet?.maxUsedCol ?? -1, MIN_OPEN_GRID_COLS, OPEN_GRID_COL_PADDING),
+      resolveInitialDisplayExtent(
+        activeSheet?.maxUsedCol ?? -1,
+        MIN_OPEN_GRID_COLS,
+        OPEN_GRID_COL_PADDING,
+        false,
+        INITIAL_WORKER_GRID_COLS
+      ),
       (activeCell?.col ?? -1) + OPEN_GRID_COL_PADDING + 1,
       (selectionEnd?.col ?? -1) + OPEN_GRID_COL_PADDING + 1,
       imageExtents.maxCol + OPEN_GRID_COL_PADDING + 1,
@@ -2978,10 +3318,6 @@ function XlsxGrid({
   }, [activeCell, activeSheet?.maxUsedCol, activeSheet?.maxUsedRow, images, normalizedSelection, shapes]);
 
   React.useEffect(() => {
-    cellRenderCacheRef.current.clear();
-  }, [activeSheetIndex, displayColLimit, displayRowLimit, palette, revision, worksheet]);
-
-  React.useEffect(() => {
     if (shouldVirtualizeRows) {
       rowVirtualizer.scrollToOffset(0);
     } else if (scrollRef.current) {
@@ -2990,6 +3326,7 @@ function XlsxGrid({
     if (scrollRef.current) {
       scrollRef.current.scrollLeft = 0;
     }
+    setScrollPosition({ left: 0, top: 0 });
   }, [activeSheetIndex, rowVirtualizer, shouldVirtualizeRows]);
 
   React.useEffect(() => {
@@ -3023,6 +3360,14 @@ function XlsxGrid({
 
     function handleScroll() {
       cachedScrollerRectRef.current = null;
+      setScrollPosition((current) =>
+        current.top === currentScroller.scrollTop && current.left === currentScroller.scrollLeft
+          ? current
+          : {
+              left: currentScroller.scrollLeft,
+              top: currentScroller.scrollTop
+            }
+      );
 
       if (
         currentScroller.scrollHeight - (currentScroller.scrollTop + currentScroller.clientHeight) <
@@ -3249,8 +3594,28 @@ function XlsxGrid({
     focusGrid();
   }, [focusGrid]);
 
-  const viewportRowBatch = React.useMemo<WorksheetBatchWindow | null>(() => {
-    if (!shouldVirtualizeRows || !worksheet) {
+  const [, startBatchTransition] = React.useTransition();
+  const [asyncViewportRowBatch, setAsyncViewportRowBatch] = React.useState<WorksheetBatchWindow | null>(null);
+  const viewportRequest = React.useMemo(() => {
+    const firstVirtualRowIndex = currentRowVirtualItems[0]?.index;
+    const lastVirtualRowIndex = currentRowVirtualItems[currentRowVirtualItems.length - 1]?.index;
+    const firstVisibleRow = firstVirtualRowIndex === undefined ? undefined : visibleRows[firstVirtualRowIndex];
+    const lastVisibleRow = lastVirtualRowIndex === undefined ? undefined : visibleRows[lastVirtualRowIndex];
+    if (firstVisibleRow === undefined || lastVisibleRow === undefined || lastVisibleRow < firstVisibleRow) {
+      return null;
+    }
+
+    const overscan = 48;
+    const startRow = Math.max(0, firstVisibleRow - overscan);
+    const endRow = lastVisibleRow + overscan;
+    return {
+      endRow,
+      startRow
+    };
+  }, [currentRowVirtualItems, visibleRows]);
+
+  const syncViewportRowBatch = React.useMemo<WorksheetBatchWindow | null>(() => {
+    if (!shouldVirtualizeRows || !worksheet || getRowsBatchAsync || !viewportRequest) {
       return null;
     }
 
@@ -3259,63 +3624,79 @@ function XlsxGrid({
       return null;
     }
 
-    const virtualItems = rowVirtualizer.getVirtualItems();
-    const firstVirtualRowIndex = virtualItems[0]?.index;
-    const lastVirtualRowIndex = virtualItems[virtualItems.length - 1]?.index;
-    const startRow =
-      firstVirtualRowIndex === undefined ? undefined : visibleRows[firstVirtualRowIndex];
-    const endRow =
-      lastVirtualRowIndex === undefined ? undefined : visibleRows[lastVirtualRowIndex];
-
-    if (startRow === undefined || endRow === undefined || endRow < startRow) {
-      return null;
-    }
-
     try {
-      const rows = worksheetWithRowsBatch.getRowsBatch(startRow, endRow - startRow + 1, {
+      const rows = worksheetWithRowsBatch.getRowsBatch(viewportRequest.startRow, viewportRequest.endRow - viewportRequest.startRow + 1, {
         includeFormulas: true,
         includeHyperlinks: true,
         includeMergeInfo: true,
         includeStyles: true,
         useFormattedValues: true
       });
-      const cells = new Map<string, BatchedCellData>();
-
-      if (Array.isArray(rows)) {
-        for (const rowEntry of rows as WorksheetBatchRowEntry[]) {
-          const row = asNonNegativeInteger(rowEntry.index);
-          if (row === null || !Array.isArray(rowEntry.cells)) {
-            continue;
-          }
-
-          for (const cellEntry of rowEntry.cells as WorksheetBatchCellEntry[]) {
-            const col = asNonNegativeInteger(cellEntry.col);
-            if (col === null) {
-              continue;
-            }
-
-            const formula = typeof cellEntry.formula === "string" ? cellEntry.formula : null;
-            cells.set(`${row}:${col}`, {
-              formula,
-              hyperlink: normalizeBatchedHyperlink(cellEntry.hyperlink),
-              isMergedSecondary: cellEntry.isMergedSecondary === true,
-              mergeSpan: normalizeBatchedMergeSpan(cellEntry.mergeSpan),
-              style: asRecord(cellEntry.style),
-              value: normalizeBatchedCellValue(cellEntry.value, formula, row, col, activeSheet)
-            });
-          }
-        }
-      }
-
-      return {
-        cells,
-        endRow,
-        startRow
-      };
+      return buildWorksheetBatchWindow(rows as unknown[] | null, activeSheet ?? null, viewportRequest.startRow, viewportRequest.endRow);
     } catch {
       return null;
     }
-  }, [activeSheet, revision, rowVirtualizer, shouldVirtualizeRows, visibleRows, worksheet]);
+  }, [activeSheet, getRowsBatchAsync, shouldVirtualizeRows, viewportRequest, worksheet]);
+
+  React.useEffect(() => {
+    if (!shouldVirtualizeRows || !getRowsBatchAsync || !activeSheet || !viewportRequest) {
+      setAsyncViewportRowBatch(null);
+      return;
+    }
+
+    if (
+      asyncViewportRowBatch
+      && viewportRequest.startRow >= asyncViewportRowBatch.startRow
+      && viewportRequest.endRow <= asyncViewportRowBatch.endRow
+    ) {
+      return;
+    }
+
+    let isCurrent = true;
+    void getRowsBatchAsync(
+      activeSheet.workbookSheetIndex,
+      viewportRequest.startRow,
+      viewportRequest.endRow - viewportRequest.startRow + 1
+    )
+      .then((rows) => {
+        if (!isCurrent) {
+          return;
+        }
+
+        const nextBatch = buildWorksheetBatchWindow(
+          rows,
+          activeSheet,
+          viewportRequest.startRow,
+          viewportRequest.endRow
+        );
+        startBatchTransition(() => {
+          setAsyncViewportRowBatch(nextBatch);
+        });
+      })
+      .catch(() => {
+        if (!isCurrent) {
+          return;
+        }
+
+        startBatchTransition(() => {
+          setAsyncViewportRowBatch(null);
+        });
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [activeSheet, asyncViewportRowBatch, getRowsBatchAsync, shouldVirtualizeRows, startBatchTransition, viewportRequest]);
+
+  const viewportRowBatch = getRowsBatchAsync ? asyncViewportRowBatch : syncViewportRowBatch;
+
+  React.useEffect(() => {
+    cellRenderCacheRef.current.clear();
+  }, [activeSheetIndex, displayColLimit, displayRowLimit, palette, revision, viewportRowBatch, worksheet]);
+
+  React.useEffect(() => {
+    setAsyncViewportRowBatch(null);
+  }, [activeSheetIndex, revision]);
 
   const getCellData = React.useCallback((row: number, col: number): CellRenderData => {
     const cacheKey = `${row}:${col}`;
@@ -3324,13 +3705,17 @@ function XlsxGrid({
       return cached;
     }
 
-    if (!worksheet) {
+    const batchCoversRow = viewportRowBatch ? row >= viewportRowBatch.startRow && row <= viewportRowBatch.endRow : false;
+    const batchedCell = batchCoversRow ? viewportRowBatch?.cells.get(cacheKey) : undefined;
+
+    if (!worksheet && !batchedCell) {
       const emptyData: CellRenderData = {
         isMergedSecondary: false,
         style: {
           backgroundColor: resolveSheetSurface(activeSheet, palette),
-          borderBottom: activeSheet?.showGridLines ? `1px solid ${SHEET_GRIDLINE}` : "none",
-          borderRight: activeSheet?.showGridLines ? `1px solid ${SHEET_GRIDLINE}` : "none",
+          borderBottom: "none",
+          borderRight: "none",
+          boxShadow: activeSheet?.showGridLines ? buildGridlineShadow(palette.border) : undefined,
           padding: DEFAULT_CELL_PADDING,
           verticalAlign: "bottom",
           whiteSpace: "nowrap"
@@ -3340,9 +3725,6 @@ function XlsxGrid({
       cellRenderCacheRef.current.set(cacheKey, emptyData);
       return emptyData;
     }
-
-    const batchCoversRow = viewportRowBatch ? row >= viewportRowBatch.startRow && row <= viewportRowBatch.endRow : false;
-    const batchedCell = batchCoversRow ? viewportRowBatch?.cells.get(cacheKey) : undefined;
 
     if (batchedCell?.isMergedSecondary) {
       const mergedSecondaryData: CellRenderData = {
@@ -3354,7 +3736,7 @@ function XlsxGrid({
       return mergedSecondaryData;
     }
 
-    if (!batchedCell && !batchCoversRow && worksheet.isMergedSecondary(row, col)) {
+    if (!batchedCell && !batchCoversRow && worksheet?.isMergedSecondary(row, col)) {
       const mergedSecondaryData: CellRenderData = {
         isMergedSecondary: true,
         style: {},
@@ -3366,37 +3748,41 @@ function XlsxGrid({
 
     const merge = batchCoversRow
       ? batchedCell?.mergeSpan
-      : (worksheet.getMergeSpan(row, col) as { colSpan?: number; rowSpan?: number } | null | undefined);
+      : (worksheet?.getMergeSpan(row, col) as { colSpan?: number; rowSpan?: number } | null | undefined);
     const rawStyle = batchCoversRow
       ? batchedCell?.style ?? resolveInheritedCellStyle(activeSheet, row, col)
       : (
-          worksheet.getCellStyleAt(row, col) as Record<string, unknown> | null | undefined
+          worksheet?.getCellStyleAt(row, col) as Record<string, unknown> | null | undefined
         ) ?? resolveInheritedCellStyle(activeSheet, row, col);
     const table = getTableAtCell(effectiveTables, row, col);
     const tableStyle = resolveTableCellStyle(table, row, col, activeSheet);
     const headerRowCount = table ? Math.max(table.headerRowCount, 1) : 0;
     const rawHyperlink = batchCoversRow
       ? batchedCell?.hyperlink
-      : (worksheet.getHyperlinkAt(row, col) as
+      : (worksheet?.getHyperlinkAt(row, col) as
           | { location?: string; target?: string; tooltip?: string }
           | null
           | undefined);
     const nextData: CellRenderData = {
       colSpan: merge?.colSpan,
-      conditionalDataBar: resolveConditionalDataBarForCell(
-        row,
-        col,
-        worksheet,
-        activeSheet,
-        conditionalFormatMetricsCacheRef.current
-      ),
-      conditionalIcon: resolveConditionalIconForCell(
-        row,
-        col,
-        worksheet,
-        activeSheet,
-        conditionalFormatMetricsCacheRef.current
-      ),
+      conditionalDataBar: worksheet
+        ? resolveConditionalDataBarForCell(
+            row,
+            col,
+            worksheet,
+            activeSheet,
+            conditionalFormatMetricsCacheRef.current
+          )
+        : null,
+      conditionalIcon: worksheet
+        ? resolveConditionalIconForCell(
+            row,
+            col,
+            worksheet,
+            activeSheet,
+            conditionalFormatMetricsCacheRef.current
+          )
+        : null,
       hyperlink: rawHyperlink ?? null,
       isMergedSecondary: false,
       isTableHeader: Boolean(table && row >= table.start.row && row < table.start.row + headerRowCount),
@@ -3405,7 +3791,7 @@ function XlsxGrid({
         showGridLines: activeSheet?.showGridLines
       }),
       validation: resolveCellDataValidation(row, col, activeSheet),
-      value: batchCoversRow ? batchedCell?.value ?? "" : getCellDisplayValue(worksheet, row, col, activeSheet)
+      value: batchCoversRow || !worksheet ? batchedCell?.value ?? "" : getCellDisplayValue(worksheet, row, col, activeSheet)
     };
 
     if (canCellTextOverflow(nextData)) {
@@ -4621,6 +5007,15 @@ function XlsxGrid({
               }}
             >
               {shapeRects.map(({ shape, rect }) => {
+                const frozenOffsets = resolveFrozenDrawingOffsets(
+                  shape.anchor,
+                  activeSheet?.freezePanes ?? null,
+                  stickyTopByRow,
+                  stickyLeftByCol,
+                  scrollPosition.top,
+                  scrollPosition.left
+                );
+                const isFrozenDrawing = frozenOffsets.left !== undefined || frozenOffsets.top !== undefined;
                 const inset = shape.textBox?.insetPx;
                 const groupScaleX = shape.scaleX ?? 1;
                 const groupScaleY = shape.scaleY ?? 1;
@@ -4666,8 +5061,11 @@ function XlsxGrid({
                     onClick={() => handleShapeClick(shape)}
                     style={{
                       ...style,
+                      left: frozenOffsets.left ?? style.left,
+                      top: frozenOffsets.top ?? style.top,
                       cursor: shape.hyperlink ? "pointer" : "default",
-                      pointerEvents: shape.hyperlink ? "auto" : "none"
+                      pointerEvents: shape.hyperlink ? "auto" : "none",
+                      zIndex: isFrozenDrawing ? shape.zIndex + 20 : style.zIndex
                     }}
                     title={shape.description}
                   >
@@ -4733,15 +5131,24 @@ function XlsxGrid({
               })}
               {imageRects.map(({ image, rect }) => {
                 const canEditImage = !readOnly && image.editable !== false;
+                const frozenOffsets = resolveFrozenDrawingOffsets(
+                  image.anchor,
+                  activeSheet?.freezePanes ?? null,
+                  stickyTopByRow,
+                  stickyLeftByCol,
+                  scrollPosition.top,
+                  scrollPosition.left
+                );
+                const isFrozenDrawing = frozenOffsets.left !== undefined || frozenOffsets.top !== undefined;
                 const style: React.CSSProperties = {
                   height: rect.height,
-                  left: rect.left,
+                  left: frozenOffsets.left ?? rect.left,
                   overflow: "hidden",
                   pointerEvents: "none",
                   position: "absolute",
-                  top: rect.top,
+                  top: frozenOffsets.top ?? rect.top,
                   width: rect.width,
-                  zIndex: image.zIndex
+                  zIndex: isFrozenDrawing ? image.zIndex + 20 : image.zIndex
                 };
                 const defaultNode = (
                   <img
@@ -4763,7 +5170,7 @@ function XlsxGrid({
                       ...style,
                       overflow: "visible",
                       pointerEvents: "none",
-                      zIndex: image.zIndex + 2
+                      zIndex: isFrozenDrawing ? image.zIndex + 22 : image.zIndex + 2
                     }}
                   >
                     {renderImageSelection
@@ -4841,7 +5248,7 @@ function XlsxGrid({
                         background: "transparent",
                         cursor: canEditImage ? "move" : image.hyperlink ? "pointer" : "default",
                         pointerEvents: "auto",
-                        zIndex: image.zIndex + 1
+                        zIndex: isFrozenDrawing ? image.zIndex + 21 : image.zIndex + 1
                       }}
                     />
                     {selectionNode}

--- a/packages/react-xlsx/src/XlsxViewer.tsx
+++ b/packages/react-xlsx/src/XlsxViewer.tsx
@@ -543,28 +543,39 @@ function resolveShapeAnchorExtents(shape: XlsxShape) {
 }
 
 function resolveFrozenDrawingOffsets(
-  anchor: XlsxImage["anchor"] | XlsxShape["anchor"],
+  rect: XlsxImageRect,
+  frozenRows: number[],
+  frozenCols: number[],
+  actualRowHeights: number[],
+  actualColWidths: number[],
   freezePanes: XlsxSheetData["freezePanes"] | null,
   stickyTopByRow: Map<number, number>,
   stickyLeftByCol: Map<number, number>,
   scrollTop: number,
   scrollLeft: number
 ) {
-  const bounds = resolveAnchoredBounds(anchor);
-  if (!bounds) {
-    return {
-      left: undefined,
-      top: undefined
-    };
-  }
+  const frozenPaneBottom =
+    freezePanes?.row && freezePanes.row > 0 && frozenRows.length > 0
+      ? frozenRows.reduce(
+          (max, row) => Math.max(max, (stickyTopByRow.get(row) ?? HEADER_HEIGHT) + (actualRowHeights[row] ?? DEFAULT_ROW_HEIGHT)),
+          HEADER_HEIGHT
+        )
+      : null;
+  const frozenPaneRight =
+    freezePanes?.col && freezePanes.col > 0 && frozenCols.length > 0
+      ? frozenCols.reduce(
+          (max, col) => Math.max(max, (stickyLeftByCol.get(col) ?? ROW_HEADER_WIDTH) + (actualColWidths[col] ?? DEFAULT_COL_WIDTH)),
+          ROW_HEADER_WIDTH
+        )
+      : null;
 
   const top =
-    freezePanes?.row && freezePanes.row > 0 && bounds.maxRow < freezePanes.row
-      ? (stickyTopByRow.get(bounds.minRow) ?? 0) + scrollTop
+    frozenPaneBottom !== null && rect.top + rect.height <= frozenPaneBottom + 0.5
+      ? rect.top + scrollTop
       : undefined;
   const left =
-    freezePanes?.col && freezePanes.col > 0 && bounds.maxCol < freezePanes.col
-      ? (stickyLeftByCol.get(bounds.minCol) ?? 0) + scrollLeft
+    frozenPaneRight !== null && rect.left + rect.width <= frozenPaneRight + 0.5
+      ? rect.left + scrollLeft
       : undefined;
 
   return {
@@ -3331,7 +3342,7 @@ function XlsxGrid({
 
   React.useEffect(() => {
     setOpenTableMenu(null);
-  }, [activeSheetIndex]);
+  }, [activeSheet, activeSheetIndex]);
 
   React.useEffect(() => {
     if (!pendingNavigation || pendingNavigation.sheetIndex !== activeSheetIndex) {
@@ -5008,7 +5019,11 @@ function XlsxGrid({
             >
               {shapeRects.map(({ shape, rect }) => {
                 const frozenOffsets = resolveFrozenDrawingOffsets(
-                  shape.anchor,
+                  rect,
+                  frozenRows,
+                  frozenCols,
+                  actualRowHeights,
+                  actualColWidths,
                   activeSheet?.freezePanes ?? null,
                   stickyTopByRow,
                   stickyLeftByCol,
@@ -5132,7 +5147,11 @@ function XlsxGrid({
               {imageRects.map(({ image, rect }) => {
                 const canEditImage = !readOnly && image.editable !== false;
                 const frozenOffsets = resolveFrozenDrawingOffsets(
-                  image.anchor,
+                  rect,
+                  frozenRows,
+                  frozenCols,
+                  actualRowHeights,
+                  actualColWidths,
                   activeSheet?.freezePanes ?? null,
                   stickyTopByRow,
                   stickyLeftByCol,

--- a/packages/react-xlsx/src/XlsxViewer.tsx
+++ b/packages/react-xlsx/src/XlsxViewer.tsx
@@ -542,7 +542,9 @@ function resolveShapeAnchorExtents(shape: XlsxShape) {
   };
 }
 
-function resolveFrozenDrawingOffsets(
+type FrozenDrawingPane = "corner" | "left" | "scroll" | "top";
+
+function resolveFrozenDrawingPane(
   rect: XlsxImageRect,
   frozenRows: number[],
   frozenCols: number[],
@@ -550,10 +552,8 @@ function resolveFrozenDrawingOffsets(
   actualColWidths: number[],
   freezePanes: XlsxSheetData["freezePanes"] | null,
   stickyTopByRow: Map<number, number>,
-  stickyLeftByCol: Map<number, number>,
-  scrollTop: number,
-  scrollLeft: number
-) {
+  stickyLeftByCol: Map<number, number>
+): FrozenDrawingPane {
   const frozenPaneBottom =
     freezePanes?.row && freezePanes.row > 0 && frozenRows.length > 0
       ? frozenRows.reduce(
@@ -569,19 +569,19 @@ function resolveFrozenDrawingOffsets(
         )
       : null;
 
-  const top =
-    frozenPaneBottom !== null && rect.top + rect.height <= frozenPaneBottom + 0.5
-      ? rect.top + scrollTop
-      : undefined;
-  const left =
-    frozenPaneRight !== null && rect.left + rect.width <= frozenPaneRight + 0.5
-      ? rect.left + scrollLeft
-      : undefined;
+  const freezeTop = frozenPaneBottom !== null && rect.top + rect.height <= frozenPaneBottom + 0.5;
+  const freezeLeft = frozenPaneRight !== null && rect.left + rect.width <= frozenPaneRight + 0.5;
 
-  return {
-    left,
-    top
-  };
+  if (freezeTop && freezeLeft) {
+    return "corner";
+  }
+  if (freezeTop) {
+    return "top";
+  }
+  if (freezeLeft) {
+    return "left";
+  }
+  return "scroll";
 }
 
 function buildShapeContainerStyle(shape: XlsxShape, rect: XlsxImageRect): React.CSSProperties {
@@ -2840,7 +2840,6 @@ function XlsxGrid({
   const rowElementRefs = React.useRef(new Map<number, HTMLTableRowElement>());
   const columnPreviewRef = React.useRef<{ actualIndex: number; size: number } | null>(null);
   const rowPreviewRef = React.useRef<{ actualIndex: number; size: number } | null>(null);
-  const [scrollPosition, setScrollPosition] = React.useState({ left: 0, top: 0 });
   const activeCellRef = React.useRef<XlsxCellAddress | null>(activeCell);
   const selectionRef = React.useRef<XlsxCellRange | null>(null);
   const editingCellRef = React.useRef<XlsxCellAddress | null>(null);
@@ -3337,7 +3336,6 @@ function XlsxGrid({
     if (scrollRef.current) {
       scrollRef.current.scrollLeft = 0;
     }
-    setScrollPosition({ left: 0, top: 0 });
   }, [activeSheetIndex, rowVirtualizer, shouldVirtualizeRows]);
 
   React.useEffect(() => {
@@ -3362,44 +3360,23 @@ function XlsxGrid({
     }
   }, [activeSheetIndex, colVirtualizer, revision, rowVirtualizer, shouldVirtualizeCols, shouldVirtualizeRows, visibleCols.length, visibleRows.length]);
 
-  React.useEffect(() => {
-    const scroller = scrollRef.current;
-    if (!scroller) {
-      return;
-    }
-    const currentScroller = scroller;
-
-    function handleScroll() {
-      cachedScrollerRectRef.current = null;
-      setScrollPosition((current) =>
-        current.top === currentScroller.scrollTop && current.left === currentScroller.scrollLeft
-          ? current
-          : {
-              left: currentScroller.scrollLeft,
-              top: currentScroller.scrollTop
-            }
-      );
-
-      if (
-        currentScroller.scrollHeight - (currentScroller.scrollTop + currentScroller.clientHeight) <
-        OPEN_GRID_VERTICAL_EDGE_PX
-      ) {
-        setDisplayRowLimit((current) => current + OPEN_GRID_ROW_GROWTH);
-      }
-
-      if (
-        currentScroller.scrollWidth - (currentScroller.scrollLeft + currentScroller.clientWidth) <
-        OPEN_GRID_HORIZONTAL_EDGE_PX
-      ) {
-        setDisplayColLimit((current) => current + OPEN_GRID_COL_GROWTH);
-      }
+  const handleScrollerScroll = React.useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    const currentScroller = event.currentTarget;
+    cachedScrollerRectRef.current = null;
+    if (
+      currentScroller.scrollHeight - (currentScroller.scrollTop + currentScroller.clientHeight) <
+      OPEN_GRID_VERTICAL_EDGE_PX
+    ) {
+      setDisplayRowLimit((current) => current + OPEN_GRID_ROW_GROWTH);
     }
 
-    currentScroller.addEventListener("scroll", handleScroll, { passive: true });
-    return () => {
-      currentScroller.removeEventListener("scroll", handleScroll);
-    };
-  }, [activeSheetIndex]);
+    if (
+      currentScroller.scrollWidth - (currentScroller.scrollLeft + currentScroller.clientWidth) <
+      OPEN_GRID_HORIZONTAL_EDGE_PX
+    ) {
+      setDisplayColLimit((current) => current + OPEN_GRID_COL_GROWTH);
+    }
+  }, []);
 
   React.useEffect(() => {
     if (!openTableMenu) {
@@ -4618,6 +4595,303 @@ function XlsxGrid({
     height: "100%",
     zIndex: 5
   };
+  function resolveDrawingPane(rect: XlsxImageRect) {
+    return resolveFrozenDrawingPane(
+      rect,
+      frozenRows,
+      frozenCols,
+      actualRowHeights,
+      actualColWidths,
+      activeSheet?.freezePanes ?? null,
+      stickyTopByRow,
+      stickyLeftByCol
+    );
+  }
+
+  function renderShapeDrawing(shape: XlsxShape, rect: XlsxImageRect, pane: FrozenDrawingPane) {
+    const drawingPane = resolveDrawingPane(rect);
+    if (drawingPane !== pane) {
+      return null;
+    }
+
+    const isFrozenDrawing = pane !== "scroll";
+    const inset = shape.textBox?.insetPx;
+    const groupScaleX = shape.scaleX ?? 1;
+    const groupScaleY = shape.scaleY ?? 1;
+    const strokeScale = Math.max(groupScaleX, groupScaleY);
+    const textScale = strokeScale;
+    const textWidth = groupScaleX !== 0 ? rect.width / groupScaleX : rect.width;
+    const textHeight = groupScaleY !== 0 ? rect.height / groupScaleY : rect.height;
+    const vectorShape = resolveShapeVector(shape);
+    const strokeColor = shape.stroke?.none ? "transparent" : (shape.stroke?.color ?? "transparent");
+    const scaledStrokeWidth = (shape.stroke?.widthPx ?? (shape.geometry === "line" ? 2 : 1)) * strokeScale;
+    const headMarkerId = `${shape.id}-${pane}-head-marker`;
+    const tailMarkerId = `${shape.id}-${pane}-tail-marker`;
+    const headMarker = vectorShape
+      ? resolveShapeLineEndMarker(
+          shape.stroke?.headEndType,
+          headMarkerId,
+          strokeColor,
+          scaledStrokeWidth,
+          rect,
+          vectorShape.viewBox
+        )
+      : null;
+    const tailMarker = vectorShape
+      ? resolveShapeLineEndMarker(
+          shape.stroke?.tailEndType,
+          tailMarkerId,
+          strokeColor,
+          scaledStrokeWidth,
+          rect,
+          vectorShape.viewBox
+        )
+      : null;
+    const style = {
+      ...buildShapeContainerStyle(shape, rect),
+      ...(vectorShape ? {
+        backgroundColor: "transparent",
+        border: "none"
+      } : null)
+    };
+
+    return (
+      <div
+        key={`${pane}-${shape.id}`}
+        onClick={() => handleShapeClick(shape)}
+        style={{
+          ...style,
+          cursor: shape.hyperlink ? "pointer" : "default",
+          left: style.left,
+          pointerEvents: shape.hyperlink ? "auto" : "none",
+          top: style.top,
+          zIndex: isFrozenDrawing ? shape.zIndex + 20 : style.zIndex
+        }}
+        title={shape.description}
+      >
+        {vectorShape ? (
+          <svg
+            aria-hidden="true"
+            preserveAspectRatio="none"
+            style={{
+              height: "100%",
+              inset: 0,
+              position: "absolute",
+              width: "100%"
+            }}
+            viewBox={`0 0 ${vectorShape.viewBox.width} ${vectorShape.viewBox.height}`}
+          >
+            {headMarker || tailMarker ? <defs>{headMarker}{tailMarker}</defs> : null}
+            <path
+              d={vectorShape.path}
+              fill={shape.fill?.none ? "transparent" : (shape.fill?.color ?? "transparent")}
+              fillOpacity={shape.fill?.opacity ?? 1}
+              markerEnd={tailMarker ? `url(#${tailMarkerId})` : undefined}
+              markerStart={headMarker ? `url(#${headMarkerId})` : undefined}
+              stroke={strokeColor}
+              strokeOpacity={shape.stroke?.opacity ?? 1}
+              strokeWidth={scaledStrokeWidth}
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+        ) : null}
+        <div
+          style={{
+            color: "#000000",
+            display: "flex",
+            flex: 1,
+            flexDirection: "column",
+            gap: 2,
+            height: textHeight,
+            justifyContent:
+              shape.textBox?.verticalAlign === "middle"
+                ? "center"
+                : shape.textBox?.verticalAlign === "bottom"
+                  ? "flex-end"
+                  : "flex-start",
+            paddingBottom: inset?.bottom ?? 4,
+            paddingLeft: inset?.left ?? 6,
+            paddingRight: inset?.right ?? 6,
+            paddingTop: inset?.top ?? 4,
+            pointerEvents: "none",
+            position: "relative",
+            transform:
+              groupScaleX !== 1 || groupScaleY !== 1
+                ? `scale(${groupScaleX}, ${groupScaleY})`
+                : undefined,
+            transformOrigin: "top left",
+            width: textWidth,
+            zIndex: 1
+          }}
+        >
+          {shape.paragraphs.map((paragraph, index) => renderShapeParagraph(paragraph, index, textScale))}
+        </div>
+      </div>
+    );
+  }
+
+  function renderImageDrawing(
+    image: XlsxImage,
+    rect: XlsxImageRect,
+    pane: FrozenDrawingPane
+  ) {
+    const drawingPane = resolveDrawingPane(rect);
+    if (drawingPane !== pane) {
+      return null;
+    }
+
+    const isFrozenDrawing = pane !== "scroll";
+    const canEditImage = !readOnly && image.editable !== false;
+    const style: React.CSSProperties = {
+      height: rect.height,
+      left: rect.left,
+      overflow: "hidden",
+      pointerEvents: "none",
+      position: "absolute",
+      top: rect.top,
+      width: rect.width,
+      zIndex: isFrozenDrawing ? image.zIndex + 20 : image.zIndex
+    };
+    const defaultNode = (
+      <img
+        alt={image.description ?? image.name ?? ""}
+        draggable={false}
+        src={image.src}
+        style={{
+          display: "block",
+          height: "100%",
+          pointerEvents: "none",
+          userSelect: "none",
+          width: "100%"
+        }}
+      />
+    );
+    const selectionNode = selectedImageId === image.id ? (
+      <div
+        style={{
+          ...style,
+          overflow: "visible",
+          pointerEvents: "none",
+          zIndex: isFrozenDrawing ? image.zIndex + 22 : image.zIndex + 2
+        }}
+      >
+        {renderImageSelection
+          ? renderImageSelection({
+              defaultNode: (
+                <div
+                  style={{
+                    border: `1.5px solid ${selectionStroke}`,
+                    boxShadow: `0 0 0 1px ${palette.surface}`,
+                    boxSizing: "border-box",
+                    inset: 0,
+                    pointerEvents: "none",
+                    position: "absolute"
+                  }}
+                >
+                  {canEditImage
+                    ? IMAGE_HANDLE_POSITIONS.map((position) => (
+                        <div
+                          key={position}
+                          onPointerDown={(event) => startImageResize(event, image, rect, position)}
+                          style={resolveImageHandleStyle(position, selectionStroke, palette.surface)}
+                        />
+                      ))
+                    : null}
+                </div>
+              ),
+              getHandleProps: (position) => ({
+                onPointerDown: (event) => {
+                  if (canEditImage) {
+                    startImageResize(event, image, rect, position);
+                  }
+                },
+                style: canEditImage
+                  ? resolveImageHandleStyle(position, selectionStroke, palette.surface)
+                  : { ...resolveImageHandleStyle(position, selectionStroke, palette.surface), display: "none" }
+              }),
+              image,
+              rect
+            })
+          : (
+              <div
+                style={{
+                  border: `1.5px solid ${selectionStroke}`,
+                  boxShadow: `0 0 0 1px ${palette.surface}`,
+                  boxSizing: "border-box",
+                  inset: 0,
+                  pointerEvents: "none",
+                  position: "absolute"
+                }}
+              >
+                {canEditImage
+                  ? IMAGE_HANDLE_POSITIONS.map((position) => (
+                      <div
+                        key={position}
+                        onPointerDown={(event) => startImageResize(event, image, rect, position)}
+                        style={resolveImageHandleStyle(position, selectionStroke, palette.surface)}
+                      />
+                    ))
+                  : null}
+              </div>
+            )}
+      </div>
+    ) : null;
+
+    return (
+      <React.Fragment key={`${pane}-${image.id}`}>
+        {renderImage
+          ? <div style={style}>{renderImage({ defaultNode, image, rect, style })}</div>
+          : <div style={style}>{defaultNode}</div>}
+        <div
+          onClick={() => handleImageClick(image)}
+          onPointerDown={(event) => startImageMove(event, image, rect)}
+          style={{
+            ...style,
+            background: "transparent",
+            cursor: canEditImage ? "move" : image.hyperlink ? "pointer" : "default",
+            pointerEvents: "auto",
+            zIndex: isFrozenDrawing ? image.zIndex + 21 : image.zIndex + 1
+          }}
+        />
+        {selectionNode}
+      </React.Fragment>
+    );
+  }
+
+  const scrollOverlayStyle: React.CSSProperties = {
+    inset: 0,
+    pointerEvents: "none",
+    position: "absolute",
+    zIndex: 20
+  };
+  const topOverlayStyle: React.CSSProperties = {
+    height: 0,
+    overflow: "visible",
+    pointerEvents: "none",
+    position: "sticky",
+    top: 0,
+    width: 0,
+    zIndex: 20
+  };
+  const leftOverlayStyle: React.CSSProperties = {
+    height: 0,
+    left: 0,
+    overflow: "visible",
+    pointerEvents: "none",
+    position: "sticky",
+    width: 0,
+    zIndex: 20
+  };
+  const cornerOverlayStyle: React.CSSProperties = {
+    height: 0,
+    left: 0,
+    overflow: "visible",
+    pointerEvents: "none",
+    position: "sticky",
+    top: 0,
+    width: 0,
+    zIndex: 20
+  };
 
   function startColumnResize(pointerId: number, actualCol: number, widthPx: number, startX: number) {
     if (readOnly) {
@@ -4839,6 +5113,7 @@ function XlsxGrid({
       <div
         key={activeSheetIndex}
         ref={scrollRef}
+        onScroll={handleScrollerScroll}
         onCopy={(event) => {
           if (editingCell) {
             return;
@@ -5009,272 +5284,24 @@ function XlsxGrid({
           }}
         >
           {showImages ? (
-            <div
-              style={{
-                inset: 0,
-                pointerEvents: "none",
-                position: "absolute",
-                zIndex: 20
-              }}
-            >
-              {shapeRects.map(({ shape, rect }) => {
-                const frozenOffsets = resolveFrozenDrawingOffsets(
-                  rect,
-                  frozenRows,
-                  frozenCols,
-                  actualRowHeights,
-                  actualColWidths,
-                  activeSheet?.freezePanes ?? null,
-                  stickyTopByRow,
-                  stickyLeftByCol,
-                  scrollPosition.top,
-                  scrollPosition.left
-                );
-                const isFrozenDrawing = frozenOffsets.left !== undefined || frozenOffsets.top !== undefined;
-                const inset = shape.textBox?.insetPx;
-                const groupScaleX = shape.scaleX ?? 1;
-                const groupScaleY = shape.scaleY ?? 1;
-                const strokeScale = Math.max(groupScaleX, groupScaleY);
-                const textScale = strokeScale;
-                const textWidth = groupScaleX !== 0 ? rect.width / groupScaleX : rect.width;
-                const textHeight = groupScaleY !== 0 ? rect.height / groupScaleY : rect.height;
-                const vectorShape = resolveShapeVector(shape);
-                const strokeColor = shape.stroke?.none ? "transparent" : (shape.stroke?.color ?? "transparent");
-                const scaledStrokeWidth = (shape.stroke?.widthPx ?? (shape.geometry === "line" ? 2 : 1)) * strokeScale;
-                const headMarkerId = `${shape.id}-head-marker`;
-                const tailMarkerId = `${shape.id}-tail-marker`;
-                const headMarker = vectorShape
-                  ? resolveShapeLineEndMarker(
-                      shape.stroke?.headEndType,
-                      headMarkerId,
-                      strokeColor,
-                      scaledStrokeWidth,
-                      rect,
-                      vectorShape.viewBox
-                    )
-                  : null;
-                const tailMarker = vectorShape
-                  ? resolveShapeLineEndMarker(
-                      shape.stroke?.tailEndType,
-                      tailMarkerId,
-                      strokeColor,
-                      scaledStrokeWidth,
-                      rect,
-                      vectorShape.viewBox
-                    )
-                  : null;
-                const style = {
-                  ...buildShapeContainerStyle(shape, rect),
-                  ...(vectorShape ? {
-                    backgroundColor: "transparent",
-                    border: "none"
-                  } : null)
-                };
-                return (
-                  <div
-                    key={shape.id}
-                    onClick={() => handleShapeClick(shape)}
-                    style={{
-                      ...style,
-                      left: frozenOffsets.left ?? style.left,
-                      top: frozenOffsets.top ?? style.top,
-                      cursor: shape.hyperlink ? "pointer" : "default",
-                      pointerEvents: shape.hyperlink ? "auto" : "none",
-                      zIndex: isFrozenDrawing ? shape.zIndex + 20 : style.zIndex
-                    }}
-                    title={shape.description}
-                  >
-                    {vectorShape ? (
-                      <svg
-                        aria-hidden="true"
-                        preserveAspectRatio="none"
-                        style={{
-                          height: "100%",
-                          inset: 0,
-                          position: "absolute",
-                          width: "100%"
-                        }}
-                        viewBox={`0 0 ${vectorShape.viewBox.width} ${vectorShape.viewBox.height}`}
-                      >
-                        {headMarker || tailMarker ? <defs>{headMarker}{tailMarker}</defs> : null}
-                        <path
-                          d={vectorShape.path}
-                          fill={shape.fill?.none ? "transparent" : (shape.fill?.color ?? "transparent")}
-                          fillOpacity={shape.fill?.opacity ?? 1}
-                          markerEnd={tailMarker ? `url(#${tailMarkerId})` : undefined}
-                          markerStart={headMarker ? `url(#${headMarkerId})` : undefined}
-                          stroke={strokeColor}
-                          strokeOpacity={shape.stroke?.opacity ?? 1}
-                          strokeWidth={scaledStrokeWidth}
-                          vectorEffect="non-scaling-stroke"
-                        />
-                      </svg>
-                    ) : null}
-                    <div
-                      style={{
-                        color: "#000000",
-                        display: "flex",
-                        flex: 1,
-                        flexDirection: "column",
-                        gap: 2,
-                        height: textHeight,
-                        justifyContent:
-                          shape.textBox?.verticalAlign === "middle"
-                            ? "center"
-                            : shape.textBox?.verticalAlign === "bottom"
-                              ? "flex-end"
-                              : "flex-start",
-                        paddingBottom: inset?.bottom ?? 4,
-                        paddingLeft: inset?.left ?? 6,
-                        paddingRight: inset?.right ?? 6,
-                        paddingTop: inset?.top ?? 4,
-                        pointerEvents: "none",
-                        position: "relative",
-                        transform:
-                          groupScaleX !== 1 || groupScaleY !== 1
-                            ? `scale(${groupScaleX}, ${groupScaleY})`
-                            : undefined,
-                        transformOrigin: "top left",
-                        zIndex: 1,
-                        width: textWidth
-                      }}
-                    >
-                      {shape.paragraphs.map((paragraph, index) => renderShapeParagraph(paragraph, index, textScale))}
-                    </div>
-                  </div>
-                );
-              })}
-              {imageRects.map(({ image, rect }) => {
-                const canEditImage = !readOnly && image.editable !== false;
-                const frozenOffsets = resolveFrozenDrawingOffsets(
-                  rect,
-                  frozenRows,
-                  frozenCols,
-                  actualRowHeights,
-                  actualColWidths,
-                  activeSheet?.freezePanes ?? null,
-                  stickyTopByRow,
-                  stickyLeftByCol,
-                  scrollPosition.top,
-                  scrollPosition.left
-                );
-                const isFrozenDrawing = frozenOffsets.left !== undefined || frozenOffsets.top !== undefined;
-                const style: React.CSSProperties = {
-                  height: rect.height,
-                  left: frozenOffsets.left ?? rect.left,
-                  overflow: "hidden",
-                  pointerEvents: "none",
-                  position: "absolute",
-                  top: frozenOffsets.top ?? rect.top,
-                  width: rect.width,
-                  zIndex: isFrozenDrawing ? image.zIndex + 20 : image.zIndex
-                };
-                const defaultNode = (
-                  <img
-                    alt={image.description ?? image.name ?? ""}
-                    draggable={false}
-                    src={image.src}
-                    style={{
-                      display: "block",
-                      height: "100%",
-                      pointerEvents: "none",
-                      userSelect: "none",
-                      width: "100%"
-                    }}
-                  />
-                );
-                const selectionNode = selectedImageId === image.id ? (
-                  <div
-                    style={{
-                      ...style,
-                      overflow: "visible",
-                      pointerEvents: "none",
-                      zIndex: isFrozenDrawing ? image.zIndex + 22 : image.zIndex + 2
-                    }}
-                  >
-                    {renderImageSelection
-                      ? renderImageSelection({
-                          defaultNode: (
-                            <div
-                              style={{
-                                border: `1.5px solid ${selectionStroke}`,
-                                boxShadow: `0 0 0 1px ${palette.surface}`,
-                                boxSizing: "border-box",
-                                inset: 0,
-                                pointerEvents: "none",
-                                position: "absolute"
-                              }}
-                            >
-                              {canEditImage
-                                ? IMAGE_HANDLE_POSITIONS.map((position) => (
-                                    <div
-                                      key={position}
-                                      onPointerDown={(event) => startImageResize(event, image, rect, position)}
-                                      style={resolveImageHandleStyle(position, selectionStroke, palette.surface)}
-                                    />
-                                  ))
-                                : null}
-                            </div>
-                          ),
-                          getHandleProps: (position) => ({
-                            onPointerDown: (event) => {
-                              if (canEditImage) {
-                                startImageResize(event, image, rect, position);
-                              }
-                            },
-                            style: canEditImage
-                              ? resolveImageHandleStyle(position, selectionStroke, palette.surface)
-                              : { ...resolveImageHandleStyle(position, selectionStroke, palette.surface), display: "none" }
-                          }),
-                          image,
-                          rect
-                        })
-                      : (
-                          <div
-                            style={{
-                              border: `1.5px solid ${selectionStroke}`,
-                              boxShadow: `0 0 0 1px ${palette.surface}`,
-                              boxSizing: "border-box",
-                              inset: 0,
-                              pointerEvents: "none",
-                              position: "absolute"
-                            }}
-                          >
-                            {canEditImage
-                              ? IMAGE_HANDLE_POSITIONS.map((position) => (
-                                  <div
-                                    key={position}
-                                    onPointerDown={(event) => startImageResize(event, image, rect, position)}
-                                    style={resolveImageHandleStyle(position, selectionStroke, palette.surface)}
-                                  />
-                                ))
-                              : null}
-                          </div>
-                        )}
-                  </div>
-                ) : null;
-
-                return (
-                  <React.Fragment key={image.id}>
-                    {renderImage
-                      ? <div style={style}>{renderImage({ defaultNode, image, rect, style })}</div>
-                      : <div style={style}>{defaultNode}</div>}
-                    <div
-                      onClick={() => handleImageClick(image)}
-                      onPointerDown={(event) => startImageMove(event, image, rect)}
-                      style={{
-                        ...style,
-                        background: "transparent",
-                        cursor: canEditImage ? "move" : image.hyperlink ? "pointer" : "default",
-                        pointerEvents: "auto",
-                        zIndex: isFrozenDrawing ? image.zIndex + 21 : image.zIndex + 1
-                      }}
-                    />
-                    {selectionNode}
-                  </React.Fragment>
-                );
-              })}
-            </div>
+            <>
+              <div style={topOverlayStyle}>
+                {shapeRects.map(({ shape, rect }) => renderShapeDrawing(shape, rect, "top"))}
+                {imageRects.map(({ image, rect }) => renderImageDrawing(image, rect, "top"))}
+              </div>
+              <div style={leftOverlayStyle}>
+                {shapeRects.map(({ shape, rect }) => renderShapeDrawing(shape, rect, "left"))}
+                {imageRects.map(({ image, rect }) => renderImageDrawing(image, rect, "left"))}
+              </div>
+              <div style={cornerOverlayStyle}>
+                {shapeRects.map(({ shape, rect }) => renderShapeDrawing(shape, rect, "corner"))}
+                {imageRects.map(({ image, rect }) => renderImageDrawing(image, rect, "corner"))}
+              </div>
+              <div style={scrollOverlayStyle}>
+                {shapeRects.map(({ shape, rect }) => renderShapeDrawing(shape, rect, "scroll"))}
+                {imageRects.map(({ image, rect }) => renderImageDrawing(image, rect, "scroll"))}
+              </div>
+            </>
           ) : null}
           <table
             ref={tableRef}

--- a/packages/react-xlsx/src/controller.tsx
+++ b/packages/react-xlsx/src/controller.tsx
@@ -19,6 +19,7 @@ import {
   type WorkbookTableMetadata
 } from "./images";
 import { getSheetsWasmModule } from "./wasm";
+import { XlsxWorkerClient } from "./worker-client";
 import type {
   UseXlsxViewerControllerOptions,
   XlsxCellAddress,
@@ -53,6 +54,9 @@ const GRID_ROW_HEADER_WIDTH = 40;
 const HISTORY_LIMIT = 100;
 const INTERNAL_CLIPBOARD_MIME = "application/x-react-xlsx-range+json";
 const DEFAULT_DEFER_LOADING_ABOVE_BYTES = 0;
+const MAX_INTERACTIVE_WORKSHEET_XML_BYTES = 200 * 1024 * 1024;
+const MAX_INTERACTIVE_SHARED_STRINGS_BYTES = 50 * 1024 * 1024;
+const MAX_INTERACTIVE_TOTAL_XML_BYTES = 256 * 1024 * 1024;
 const EMU_PER_PIXEL = 9525;
 const IMAGE_BATCH_ROW_COUNT = 256;
 
@@ -118,6 +122,142 @@ type WorksheetWithRowsBatch = ReturnType<Workbook["getSheet"]> & {
   getRowsBatch?: (startRow: number, maxRows: number, options?: unknown) => unknown;
 };
 
+type ZipEntryMetadata = {
+  compressedSize: number;
+  name: string;
+  uncompressedSize: number;
+};
+
+type WorkbookPreflightResult = {
+  largestWorksheetXmlBytes: number;
+  sharedStringsBytes: number;
+  totalWorksheetXmlBytes: number;
+  tooLarge: boolean;
+};
+
+function formatBinaryBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${value >= 10 || unitIndex === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+function findZipEndOfCentralDirectoryOffset(bytes: Uint8Array) {
+  const minLength = 22;
+  if (bytes.byteLength < minLength) {
+    return -1;
+  }
+
+  const searchStart = Math.max(0, bytes.byteLength - (0xffff + minLength));
+  for (let offset = bytes.byteLength - minLength; offset >= searchStart; offset -= 1) {
+    if (
+      bytes[offset] === 0x50 &&
+      bytes[offset + 1] === 0x4b &&
+      bytes[offset + 2] === 0x05 &&
+      bytes[offset + 3] === 0x06
+    ) {
+      return offset;
+    }
+  }
+
+  return -1;
+}
+
+function readZipCentralDirectoryEntries(buffer: ArrayBuffer): ZipEntryMetadata[] | null {
+  const bytes = new Uint8Array(buffer);
+  const eocdOffset = findZipEndOfCentralDirectoryOffset(bytes);
+  if (eocdOffset < 0) {
+    return null;
+  }
+
+  const view = new DataView(buffer, bytes.byteOffset, bytes.byteLength);
+  const centralDirectorySize = view.getUint32(eocdOffset + 12, true);
+  const centralDirectoryOffset = view.getUint32(eocdOffset + 16, true);
+  const decoder = new TextDecoder();
+  const entries: ZipEntryMetadata[] = [];
+
+  let offset = centralDirectoryOffset;
+  const endOffset = centralDirectoryOffset + centralDirectorySize;
+  while (offset + 46 <= endOffset && offset + 46 <= bytes.byteLength) {
+    if (view.getUint32(offset, true) !== 0x02014b50) {
+      return null;
+    }
+
+    const compressedSize = view.getUint32(offset + 20, true);
+    const uncompressedSize = view.getUint32(offset + 24, true);
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const fileNameStart = offset + 46;
+    const fileNameEnd = fileNameStart + fileNameLength;
+    if (fileNameEnd > bytes.byteLength) {
+      return null;
+    }
+
+    entries.push({
+      compressedSize,
+      name: decoder.decode(bytes.subarray(fileNameStart, fileNameEnd)),
+      uncompressedSize
+    });
+
+    offset = fileNameEnd + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+function preflightWorkbookBuffer(buffer: ArrayBuffer): WorkbookPreflightResult | null {
+  const entries = readZipCentralDirectoryEntries(buffer);
+  if (!entries) {
+    return null;
+  }
+
+  let largestWorksheetXmlBytes = 0;
+  let totalWorksheetXmlBytes = 0;
+  let sharedStringsBytes = 0;
+
+  for (const entry of entries) {
+    if (/^xl\/worksheets\/[^/]+\.xml$/i.test(entry.name)) {
+      largestWorksheetXmlBytes = Math.max(largestWorksheetXmlBytes, entry.uncompressedSize);
+      totalWorksheetXmlBytes += entry.uncompressedSize;
+      continue;
+    }
+
+    if (entry.name === "xl/sharedStrings.xml") {
+      sharedStringsBytes = entry.uncompressedSize;
+    }
+  }
+
+  const tooLarge =
+    largestWorksheetXmlBytes > MAX_INTERACTIVE_WORKSHEET_XML_BYTES ||
+    sharedStringsBytes > MAX_INTERACTIVE_SHARED_STRINGS_BYTES ||
+    totalWorksheetXmlBytes + sharedStringsBytes > MAX_INTERACTIVE_TOTAL_XML_BYTES;
+
+  return {
+    largestWorksheetXmlBytes,
+    sharedStringsBytes,
+    tooLarge,
+    totalWorksheetXmlBytes
+  };
+}
+
+function createWorkbookTooLargeError(preflight: WorkbookPreflightResult) {
+  return new Error(
+    `XLSX is too large to preview interactively. `
+    + `Largest worksheet XML: ${formatBinaryBytes(preflight.largestWorksheetXmlBytes)}; `
+    + `shared strings: ${formatBinaryBytes(preflight.sharedStringsBytes)}.`
+  );
+}
+
 type HistoryEntry = SnapshotHistoryEntry | CellEditHistoryEntry | RangeEditHistoryEntry;
 
 type ClipboardMatrixCell = {
@@ -176,6 +316,8 @@ function buildSheetList(
     defaultRowHeightPx?: number;
     hasHorizontalMerges?: boolean;
     hasVerticalMerges?: boolean;
+    hiddenCols?: number[];
+    hiddenRows?: number[];
     rowHeightOverridesPx?: Record<number, number>;
     rowStyleIds?: Record<number, number>;
     showGridLines: boolean;
@@ -225,6 +367,8 @@ function buildSheetList(
         freezePanes: parseWorksheetFreezePanes(worksheet),
         hasHorizontalMerges: sheetState?.hasHorizontalMerges ?? false,
         hasVerticalMerges: sheetState?.hasVerticalMerges ?? false,
+        hiddenCols: sheetState?.hiddenCols ?? [],
+        hiddenRows: sheetState?.hiddenRows ?? [],
         maxUsedCol: -1,
         maxUsedRow: -1,
         name: worksheet.name,
@@ -314,6 +458,8 @@ function buildSheetList(
       freezePanes: parseWorksheetFreezePanes(worksheet),
       hasHorizontalMerges: sheetState?.hasHorizontalMerges ?? false,
       hasVerticalMerges: sheetState?.hasVerticalMerges ?? false,
+      hiddenCols: sheetState?.hiddenCols ?? [],
+      hiddenRows: sheetState?.hiddenRows ?? [],
       maxUsedCol: maxCol,
       maxUsedRow: maxRow,
       name: worksheet.name,
@@ -972,11 +1118,20 @@ function downloadUrl(src: string, fileName: string) {
 }
 
 export function useXlsxViewerController(options: UseXlsxViewerControllerOptions): XlsxViewerController {
-  const { deferLoadingAboveBytes = DEFAULT_DEFER_LOADING_ABOVE_BYTES, file, fileName, readOnly = false, src } = options;
+  const {
+    deferLoadingAboveBytes = DEFAULT_DEFER_LOADING_ABOVE_BYTES,
+    file,
+    fileName,
+    readOnly: requestedReadOnly = false,
+    readOnlyAboveBytes = 0,
+    src,
+    useWorker = true
+  } = options;
   const [isLoading, setIsLoading] = React.useState(Boolean(file ?? src));
   const [error, setError] = React.useState<Error | null>(null);
   const [workbook, setWorkbook] = React.useState<Workbook | null>(null);
   const [sheets, setSheets] = React.useState<XlsxSheetData[]>([]);
+  const [workerTablesByWorkbookSheetIndex, setWorkerTablesByWorkbookSheetIndex] = React.useState<XlsxTable[][]>([]);
   const [imagesByWorkbookSheetIndex, setImagesByWorkbookSheetIndex] = React.useState<XlsxImage[][]>([]);
   const [shapesByWorkbookSheetIndex, setShapesByWorkbookSheetIndex] = React.useState<XlsxShape[][]>([]);
   const [activeSheetIndex, setActiveSheetIndexState] = React.useState(0);
@@ -990,13 +1145,37 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
   const isApplyingHistoryRef = React.useRef(false);
   const [historyRevision, setHistoryRevision] = React.useState(0);
   const [shouldAutoCalculate, setShouldAutoCalculate] = React.useState(false);
+  const [workerCellSnapshotRevision, setWorkerCellSnapshotRevision] = React.useState(0);
+  const [isWorkerBacked, setIsWorkerBacked] = React.useState(false);
   const [sortState, setSortState] = React.useState<XlsxTableSortState | null>(null);
+  const [forcedReadOnly, setForcedReadOnly] = React.useState(false);
   const deferredBufferRef = React.useRef<ArrayBuffer | null>(null);
   const [deferredLoadFileSize, setDeferredLoadFileSize] = React.useState<number | null>(null);
   const imageAssetsRef = React.useRef<WorkbookImageAssets | null>(null);
   const sheetOriginsRef = React.useRef<Array<WorkbookImageSheetOrigin | null>>([]);
+  const workerClientRef = React.useRef<XlsxWorkerClient | null>(null);
+  const workerCellSnapshotCacheRef = React.useRef(new Map<string, { displayValue: string; formula: string }>());
   const displayFileName = React.useMemo(() => resolveDisplayFileName(src, fileName), [fileName, src]);
   const shouldDeferLoading = deferLoadingAboveBytes > 0;
+  const readOnly = requestedReadOnly || forcedReadOnly;
+  const workerSupported = useWorker && typeof Worker !== "undefined";
+  const shouldUseWorker = workerSupported && readOnly;
+  const shouldForceReadOnlyForBuffer = React.useCallback((bufferByteLength: number) => (
+    !requestedReadOnly && readOnlyAboveBytes > 0 && bufferByteLength > readOnlyAboveBytes
+  ), [readOnlyAboveBytes, requestedReadOnly]);
+
+  const disposeWorkerClient = React.useCallback(() => {
+    workerClientRef.current?.dispose();
+    workerClientRef.current = null;
+  }, []);
+
+  const getWorkerClient = React.useCallback(() => {
+    if (!workerClientRef.current) {
+      workerClientRef.current = new XlsxWorkerClient();
+    }
+
+    return workerClientRef.current;
+  }, []);
 
   const clearImageAssets = React.useCallback(() => {
     revokeWorkbookImageAssets(imageAssetsRef.current);
@@ -1012,6 +1191,20 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     sheetOriginsRef.current = assets?.sheetOrigins.slice() ?? [];
     setImagesByWorkbookSheetIndex(assets?.imagesByWorkbookSheetIndex ?? []);
     setShapesByWorkbookSheetIndex(assets?.shapesByWorkbookSheetIndex ?? []);
+  }, []);
+
+  const loadWorkbookOnMainThread = React.useCallback(async (buffer: ArrayBuffer) => {
+    const nextParsedWorkbook = await parseWorkbookBuffer(buffer);
+    const nextImageAssets = loadWorkbookImageAssets(new Uint8Array(buffer), nextParsedWorkbook.workbook);
+    return {
+      imageAssets: nextImageAssets,
+      parsedWorkbook: nextParsedWorkbook
+    };
+  }, []);
+
+  const shouldFallbackFromWorkerError = React.useCallback((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error ?? "");
+    return message.includes("DOMParser is not defined") || message.includes("XMLSerializer is not defined");
   }, []);
 
   const refreshWorkbookState = React.useCallback((targetWorkbook: Workbook) => {
@@ -1030,15 +1223,20 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
 
   React.useEffect(() => () => {
     revokeWorkbookImageAssets(imageAssetsRef.current);
-  }, []);
+    disposeWorkerClient();
+  }, [disposeWorkerClient]);
 
   React.useEffect(() => {
     if (!file && !src) {
+      disposeWorkerClient();
+      setForcedReadOnly(false);
       setWorkbook(null);
       setSheets([]);
+      setWorkerTablesByWorkbookSheetIndex([]);
       clearImageAssets();
       setError(null);
       setIsLoading(false);
+      setIsWorkerBacked(false);
       deferredBufferRef.current = null;
       setDeferredLoadFileSize(null);
       setActiveSheetIndexState(0);
@@ -1050,6 +1248,8 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
       redoStackRef.current = [];
       setHistoryRevision(0);
       setShouldAutoCalculate(false);
+      workerCellSnapshotCacheRef.current.clear();
+      setWorkerCellSnapshotRevision(0);
       setSortState(null);
       setRevision(0);
       return;
@@ -1059,6 +1259,8 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     setIsLoading(true);
     setError(null);
     clearImageAssets();
+    setWorkerTablesByWorkbookSheetIndex([]);
+    setIsWorkerBacked(false);
     deferredBufferRef.current = null;
     setDeferredLoadFileSize(null);
     setActiveSheetIndexState(0);
@@ -1070,8 +1272,13 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     redoStackRef.current = [];
     setHistoryRevision(0);
     setShouldAutoCalculate(false);
+    workerCellSnapshotCacheRef.current.clear();
+    setWorkerCellSnapshotRevision(0);
     setSortState(null);
     setRevision(0);
+    if (!workerSupported) {
+      disposeWorkerClient();
+    }
 
     void resolveWorkbookBuffer({ file, src })
       .then(async (buffer) => {
@@ -1079,21 +1286,50 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
           return;
         }
 
+        const preflight = preflightWorkbookBuffer(buffer);
+        if (preflight?.tooLarge) {
+          throw createWorkbookTooLargeError(preflight);
+        }
+
+        const shouldForceReadOnly = shouldForceReadOnlyForBuffer(buffer.byteLength);
+        setForcedReadOnly(shouldForceReadOnly);
+        const shouldUseWorkerForLoad = workerSupported && (requestedReadOnly || shouldForceReadOnly);
+
         if (shouldDeferLoading && buffer.byteLength > deferLoadingAboveBytes) {
           deferredBufferRef.current = buffer;
           setDeferredLoadFileSize(buffer.byteLength);
           setWorkbook(null);
           setSheets([]);
+          setWorkerTablesByWorkbookSheetIndex([]);
           setIsLoading(false);
           return;
         }
 
-        const nextParsedWorkbook = await parseWorkbookBuffer(buffer);
-        if (!isCurrent) {
-          return;
+        if (shouldUseWorkerForLoad) {
+          try {
+            const snapshot = await getWorkerClient().loadWorkbook(buffer.slice(0));
+            if (!isCurrent) {
+              return;
+            }
+
+            setWorkbook(null);
+            setSheets(snapshot.sheets);
+            setWorkerTablesByWorkbookSheetIndex(snapshot.tablesByWorkbookSheetIndex);
+            setShouldAutoCalculate(false);
+            setIsWorkerBacked(true);
+            setSortState(null);
+            setIsLoading(false);
+            return;
+          } catch (workerError) {
+            if (!shouldFallbackFromWorkerError(workerError)) {
+              throw workerError;
+            }
+
+            disposeWorkerClient();
+          }
         }
 
-        const nextImageAssets = loadWorkbookImageAssets(new Uint8Array(buffer), nextParsedWorkbook.workbook);
+        const { imageAssets: nextImageAssets, parsedWorkbook: nextParsedWorkbook } = await loadWorkbookOnMainThread(buffer);
         if (!isCurrent) {
           revokeWorkbookImageAssets(nextImageAssets);
           return;
@@ -1112,6 +1348,8 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
           )
         );
         setShouldAutoCalculate(nextParsedWorkbook.shouldAutoCalculate);
+        setWorkerTablesByWorkbookSheetIndex([]);
+        setIsWorkerBacked(false);
         setSortState(null);
         setIsLoading(false);
       })
@@ -1122,8 +1360,10 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
 
         setWorkbook(null);
         setSheets([]);
+        setWorkerTablesByWorkbookSheetIndex([]);
         clearImageAssets();
         setShouldAutoCalculate(false);
+        setIsWorkerBacked(false);
         setSortState(null);
         setError(nextError instanceof Error ? nextError : new Error("Could not load workbook."));
         setIsLoading(false);
@@ -1131,8 +1371,23 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
 
     return () => {
       isCurrent = false;
+      if (!workerSupported) {
+        disposeWorkerClient();
+      }
     };
-  }, [clearImageAssets, deferLoadingAboveBytes, file, setImageAssets, shouldDeferLoading, src]);
+  }, [
+    clearImageAssets,
+    deferLoadingAboveBytes,
+    disposeWorkerClient,
+    file,
+    getWorkerClient,
+    requestedReadOnly,
+    setImageAssets,
+    shouldDeferLoading,
+    shouldForceReadOnlyForBuffer,
+    workerSupported,
+    src
+  ]);
 
   const activeSheet = sheets[activeSheetIndex] ?? null;
 
@@ -1161,6 +1416,83 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
 
     setIsLoading(true);
     setError(null);
+
+    const preflight = preflightWorkbookBuffer(deferredBuffer);
+    if (preflight?.tooLarge) {
+      deferredBufferRef.current = null;
+      setDeferredLoadFileSize(null);
+      setWorkbook(null);
+      setSheets([]);
+      setWorkerTablesByWorkbookSheetIndex([]);
+      clearImageAssets();
+      setShouldAutoCalculate(false);
+      setIsWorkerBacked(false);
+      setSortState(null);
+      setError(createWorkbookTooLargeError(preflight));
+      setIsLoading(false);
+      return;
+    }
+
+    const shouldForceReadOnly = shouldForceReadOnlyForBuffer(deferredBuffer.byteLength);
+    setForcedReadOnly(shouldForceReadOnly);
+    const shouldUseWorkerForLoad = workerSupported && (requestedReadOnly || shouldForceReadOnly);
+
+    if (shouldUseWorkerForLoad) {
+      void getWorkerClient().loadWorkbook(deferredBuffer.slice(0))
+        .then((snapshot) => {
+          deferredBufferRef.current = null;
+          setDeferredLoadFileSize(null);
+          setWorkbook(null);
+          setSheets(snapshot.sheets);
+          setWorkerTablesByWorkbookSheetIndex(snapshot.tablesByWorkbookSheetIndex);
+          setShouldAutoCalculate(false);
+          setIsWorkerBacked(true);
+          setSortState(null);
+          setIsLoading(false);
+        })
+        .catch(async (workerError: unknown) => {
+          if (!shouldFallbackFromWorkerError(workerError)) {
+            throw workerError;
+          }
+
+          disposeWorkerClient();
+          const { imageAssets: nextImageAssets, parsedWorkbook: nextParsedWorkbook } = await loadWorkbookOnMainThread(deferredBuffer);
+          deferredBufferRef.current = null;
+          setDeferredLoadFileSize(null);
+          setImageAssets(nextImageAssets);
+          setWorkbook(nextParsedWorkbook.workbook);
+          setSheets(
+            buildSheetList(
+              nextParsedWorkbook.workbook,
+              nextImageAssets.sheetStatesByWorkbookSheetIndex,
+              nextImageAssets.themePalette,
+              nextImageAssets.styleById,
+              nextImageAssets.namedCellStyleByName,
+              nextImageAssets.tableStyleByName
+            )
+          );
+          setShouldAutoCalculate(nextParsedWorkbook.shouldAutoCalculate);
+          setWorkerTablesByWorkbookSheetIndex([]);
+          setIsWorkerBacked(false);
+          setSortState(null);
+          setIsLoading(false);
+        })
+        .catch((nextError: unknown) => {
+          deferredBufferRef.current = null;
+          setDeferredLoadFileSize(null);
+          setWorkbook(null);
+          setSheets([]);
+          setWorkerTablesByWorkbookSheetIndex([]);
+          clearImageAssets();
+          setShouldAutoCalculate(false);
+          setIsWorkerBacked(false);
+          setSortState(null);
+          setError(nextError instanceof Error ? nextError : new Error("Could not load workbook."));
+          setIsLoading(false);
+        });
+      return;
+    }
+
     void parseWorkbookBuffer(deferredBuffer)
       .then((nextParsedWorkbook) => {
         const nextImageAssets = loadWorkbookImageAssets(new Uint8Array(deferredBuffer), nextParsedWorkbook.workbook);
@@ -1179,6 +1511,8 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
           )
         );
         setShouldAutoCalculate(nextParsedWorkbook.shouldAutoCalculate);
+        setWorkerTablesByWorkbookSheetIndex([]);
+        setIsWorkerBacked(false);
         setSortState(null);
         setIsLoading(false);
       })
@@ -1187,13 +1521,22 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
         setDeferredLoadFileSize(null);
         setWorkbook(null);
         setSheets([]);
+        setWorkerTablesByWorkbookSheetIndex([]);
         clearImageAssets();
         setShouldAutoCalculate(false);
+        setIsWorkerBacked(false);
         setSortState(null);
         setError(nextError instanceof Error ? nextError : new Error("Could not load workbook."));
         setIsLoading(false);
       });
-  }, [clearImageAssets, setImageAssets]);
+  }, [
+    clearImageAssets,
+    getWorkerClient,
+    requestedReadOnly,
+    setImageAssets,
+    shouldForceReadOnlyForBuffer,
+    workerSupported
+  ]);
 
   const maybeRecalculateWorkbook = React.useCallback((targetWorkbook: Workbook) => {
     if (!shouldAutoCalculate) {
@@ -1213,9 +1556,32 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
 
   const activeTableMetadata = imageAssetsRef.current?.tableMetadataByWorkbookSheetIndex[activeSheet?.workbookSheetIndex ?? -1] ?? null;
   const tables = React.useMemo(
-    () => mapWorksheetTables(getActiveWorksheet(), activeTableMetadata),
-    [activeTableMetadata, getActiveWorksheet, revision]
+    () => (
+      isWorkerBacked
+        ? workerTablesByWorkbookSheetIndex[activeSheet?.workbookSheetIndex ?? -1] ?? []
+        : mapWorksheetTables(getActiveWorksheet(), activeTableMetadata)
+    ),
+    [activeSheet?.workbookSheetIndex, activeTableMetadata, getActiveWorksheet, isWorkerBacked, revision, workerTablesByWorkbookSheetIndex]
   );
+
+  const getCellSnapshotAsync = React.useCallback((workbookSheetIndex: number, row: number, col: number) => {
+    if (!isWorkerBacked) {
+      return Promise.resolve({
+        displayValue: "",
+        formula: ""
+      });
+    }
+
+    return getWorkerClient().getCellSnapshot(workbookSheetIndex, row, col);
+  }, [getWorkerClient, isWorkerBacked]);
+
+  const getRowsBatchAsync = React.useCallback((workbookSheetIndex: number, startRow: number, rowCount: number) => {
+    if (!isWorkerBacked) {
+      return Promise.resolve(null);
+    }
+
+    return getWorkerClient().getRowsBatch(workbookSheetIndex, startRow, rowCount);
+  }, [getWorkerClient, isWorkerBacked]);
 
   const visibleSheetIndexByWorkbookSheetIndex = React.useMemo(
     () => new Map(sheets.map((sheet, index) => [sheet.workbookSheetIndex, index])),
@@ -1311,6 +1677,13 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
   }, [activeSheet?.showGridLines, activeSheet?.workbookSheetIndex]);
 
   const getCellDisplayValue = React.useCallback((cell?: XlsxCellAddress | null) => {
+    if (cell && activeSheet) {
+      const workerSnapshot = workerCellSnapshotCacheRef.current.get(`${activeSheet.workbookSheetIndex}:${cell.row}:${cell.col}`);
+      if (workerSnapshot) {
+        return workerSnapshot.displayValue;
+      }
+    }
+
     const worksheet = getActiveWorksheet();
     if (!worksheet || !cell) {
       return "";
@@ -1335,16 +1708,23 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     }
 
     return calculated.toString();
-  }, [activeSheet?.cachedFormulaValues, getActiveWorksheet]);
+  }, [activeSheet, getActiveWorksheet]);
 
   const getCellFormula = React.useCallback((cell?: XlsxCellAddress | null) => {
+    if (cell && activeSheet) {
+      const workerSnapshot = workerCellSnapshotCacheRef.current.get(`${activeSheet.workbookSheetIndex}:${cell.row}:${cell.col}`);
+      if (workerSnapshot) {
+        return workerSnapshot.formula;
+      }
+    }
+
     const worksheet = getActiveWorksheet();
     if (!worksheet || !cell) {
       return "";
     }
 
     return worksheet.getFormulaAt(cell.row, cell.col) ?? "";
-  }, [getActiveWorksheet]);
+  }, [activeSheet, getActiveWorksheet]);
 
   const getClipboardData = React.useCallback((): XlsxClipboardData | null => {
     const worksheet = getActiveWorksheet();
@@ -1479,10 +1859,53 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     };
   }, [activeCell, getActiveWorksheet, getCellDisplayValue, selection]);
 
+  React.useEffect(() => {
+    if (!isWorkerBacked || !activeSheet || !activeCell) {
+      return;
+    }
+
+    const cacheKey = `${activeSheet.workbookSheetIndex}:${activeCell.row}:${activeCell.col}`;
+    if (workerCellSnapshotCacheRef.current.has(cacheKey)) {
+      return;
+    }
+
+    let isCurrent = true;
+    void getCellSnapshotAsync(activeSheet.workbookSheetIndex, activeCell.row, activeCell.col)
+      .then((snapshot) => {
+        if (!isCurrent) {
+          return;
+        }
+
+        workerCellSnapshotCacheRef.current.set(cacheKey, snapshot);
+        setWorkerCellSnapshotRevision((current) => current + 1);
+      })
+      .catch(() => {
+        if (!isCurrent) {
+          return;
+        }
+
+        workerCellSnapshotCacheRef.current.set(cacheKey, {
+          displayValue: "",
+          formula: ""
+        });
+        setWorkerCellSnapshotRevision((current) => current + 1);
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [activeCell, activeSheet, getCellSnapshotAsync, isWorkerBacked]);
+
   const activeCellAddress = React.useMemo(() => (activeCell ? cellAddressToA1(activeCell) : null), [activeCell]);
   const selectedRangeAddress = React.useMemo(() => (selection ? rangeToA1(selection) : null), [selection]);
-  const selectedValue = React.useMemo(() => getCellDisplayValue(activeCell), [activeCell, getCellDisplayValue, revision]);
-  const selectedFormula = React.useMemo(() => getCellFormula(activeCell), [activeCell, getCellFormula, revision]);
+  const selectedValue = React.useMemo(
+    () => getCellDisplayValue(activeCell),
+    [activeCell, getCellDisplayValue, revision, workerCellSnapshotRevision]
+  );
+  const selectedFormula = React.useMemo(
+    () => getCellFormula(activeCell),
+    [activeCell, getCellFormula, revision, workerCellSnapshotRevision]
+  );
   const isLoadDeferred = deferredLoadFileSize !== null;
   const canLoadDeferred = !isLoading && isLoadDeferred;
   const canUndo = !readOnly && undoStackRef.current.length > 0;
@@ -2588,10 +3011,12 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
       getClipboardData,
       getCellDisplayValue,
       getCellFormula,
+      getCellSnapshotAsync: isWorkerBacked ? getCellSnapshotAsync : undefined,
       getActiveWorksheet,
       images,
       isLoadDeferred,
       isLoading,
+      isWorkerBacked,
       mergeSelection,
       moveImageBy,
       pasteFromClipboard,
@@ -2625,6 +3050,7 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
       src,
       sortState,
       sortTable,
+      getRowsBatchAsync: isWorkerBacked ? getRowsBatchAsync : undefined,
       tables,
       undo,
       unmergeSelection,
@@ -2658,11 +3084,13 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
       getClipboardData,
       getCellDisplayValue,
       getCellFormula,
+      getCellSnapshotAsync,
       getActiveWorksheet,
       historyRevision,
       images,
       isLoadDeferred,
       isLoading,
+      isWorkerBacked,
       mergeSelection,
       moveImageBy,
       pasteFromClipboard,
@@ -2696,6 +3124,7 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
       sortState,
       sortTable,
       src,
+      getRowsBatchAsync,
       tables,
       undo,
       unmergeSelection,

--- a/packages/react-xlsx/src/images.ts
+++ b/packages/react-xlsx/src/images.ts
@@ -81,9 +81,15 @@ type WorkbookSheetState = {
   defaultRowHeightPx: number;
   hasHorizontalMerges: boolean;
   hasVerticalMerges: boolean;
+  hiddenCols: number[];
+  hiddenRows: number[];
   rowHeightOverridesPx: Record<number, number>;
   rowStyleIds: Record<number, number>;
   showGridLines: boolean;
+};
+
+type ParseWorkbookStructureOptions = {
+  includeCachedFormulaValues?: boolean;
 };
 
 type ThemeState = {
@@ -162,6 +168,16 @@ export type WorkbookImageAssets = {
   tableStyleByName: Record<string, XlsxTableStyleDefinition>;
   themePalette: XlsxThemePalette;
 };
+
+export type WorkbookStructureAssets = Pick<
+  WorkbookImageAssets,
+  | "namedCellStyleByName"
+  | "sheetStatesByWorkbookSheetIndex"
+  | "styleById"
+  | "tableMetadataByWorkbookSheetIndex"
+  | "tableStyleByName"
+  | "themePalette"
+>;
 
 function buildThemePalette(theme: ThemeState): XlsxThemePalette {
   const themeOrder = ["lt1", "dk1", "lt2", "dk2", "accent1", "accent2", "accent3", "accent4", "accent5", "accent6", "hlink", "folHlink"];
@@ -1198,7 +1214,11 @@ function parseConditionalFormatRules(document: Document) {
     .sort((left, right) => left.priority - right.priority);
 }
 
-function parseSheetState(archive: ArchiveEntries, path: string): WorkbookSheetState | null {
+function parseSheetState(
+  archive: ArchiveEntries,
+  path: string,
+  options?: ParseWorkbookStructureOptions
+): WorkbookSheetState | null {
   const xml = readArchiveText(archive, path);
   if (!xml) {
     return null;
@@ -1209,6 +1229,7 @@ function parseSheetState(archive: ArchiveEntries, path: string): WorkbookSheetSt
     return null;
   }
 
+  const includeCachedFormulaValues = options?.includeCachedFormulaValues ?? true;
   const cachedFormulaValues: Record<string, string> = {};
   const conditionalFormatRules = parseConditionalFormatRules(document);
   const sheetFormatNode = getLocalElements(document, "sheetFormatPr")[0] ?? null;
@@ -1217,6 +1238,8 @@ function parseSheetState(archive: ArchiveEntries, path: string): WorkbookSheetSt
   const colWidthOverridesPx: Record<number, number> = {};
   const rowStyleIds: Record<number, number> = {};
   const colStyleIds: Record<number, number> = {};
+  const hiddenRows = new Set<number>();
+  const hiddenCols = new Set<number>();
   let hasHorizontalMerges = false;
   let hasVerticalMerges = false;
 
@@ -1231,21 +1254,27 @@ function parseSheetState(archive: ArchiveEntries, path: string): WorkbookSheetSt
     const rowIndex = Number(rowNode.getAttribute("r") ?? 0) - 1;
     const height = Number(rowNode.getAttribute("ht") ?? Number.NaN);
     const styleId = Number(rowNode.getAttribute("s") ?? Number.NaN);
+    const isHidden = (rowNode.getAttribute("hidden") ?? "0") === "1";
     if (rowIndex >= 0 && Number.isFinite(height)) {
       rowHeightOverridesPx[rowIndex] = Math.max(MIN_ROW_HEIGHT_PX, Math.round(height * 1.33));
     }
     if (rowIndex >= 0 && Number.isFinite(styleId)) {
       rowStyleIds[rowIndex] = styleId;
     }
+    if (rowIndex >= 0 && isHidden) {
+      hiddenRows.add(rowIndex);
+    }
 
-    getChildElements(rowNode, "c").forEach((cellNode) => {
-      const formulaNode = getFirstChild(cellNode, "f");
-      const valueNode = getFirstChild(cellNode, "v");
-      const cellRef = cellNode.getAttribute("r");
-      if (formulaNode && valueNode && cellRef) {
-        cachedFormulaValues[cellRef] = valueNode.textContent ?? "";
-      }
-    });
+    if (includeCachedFormulaValues) {
+      getChildElements(rowNode, "c").forEach((cellNode) => {
+        const formulaNode = getFirstChild(cellNode, "f");
+        const valueNode = getFirstChild(cellNode, "v");
+        const cellRef = cellNode.getAttribute("r");
+        if (formulaNode && valueNode && cellRef) {
+          cachedFormulaValues[cellRef] = valueNode.textContent ?? "";
+        }
+      });
+    }
   });
 
   getLocalElements(document, "col").forEach((colNode) => {
@@ -1253,6 +1282,7 @@ function parseSheetState(archive: ArchiveEntries, path: string): WorkbookSheetSt
     const max = Number(colNode.getAttribute("max") ?? 0) - 1;
     const width = Number(colNode.getAttribute("width") ?? Number.NaN);
     const styleId = Number(colNode.getAttribute("style") ?? Number.NaN);
+    const isHidden = (colNode.getAttribute("hidden") ?? "0") === "1";
     if (!Number.isFinite(width)) {
       if (!Number.isFinite(styleId)) {
         return;
@@ -1267,6 +1297,9 @@ function parseSheetState(archive: ArchiveEntries, path: string): WorkbookSheetSt
         }
         if (Number.isFinite(styleId)) {
           colStyleIds[col] = styleId;
+        }
+        if (isHidden) {
+          hiddenCols.add(col);
         }
       }
     }
@@ -1296,6 +1329,8 @@ function parseSheetState(archive: ArchiveEntries, path: string): WorkbookSheetSt
     defaultRowHeightPx: Math.max(MIN_ROW_HEIGHT_PX, Math.round(defaultRowHeight * 1.33)),
     hasHorizontalMerges,
     hasVerticalMerges,
+    hiddenCols: [...hiddenCols].sort((left, right) => left - right),
+    hiddenRows: [...hiddenRows].sort((left, right) => left - right),
     rowHeightOverridesPx,
     rowStyleIds,
     showGridLines: (sheetViewNode?.getAttribute("showGridLines") ?? "1") !== "0"
@@ -2373,18 +2408,73 @@ export function revokeWorkbookImageAssets(assets: WorkbookImageAssets | null) {
   }
 }
 
-export function parseWorkbookImageAssets(bytes: Uint8Array): WorkbookImageAssets {
-  const archive = unzipSync(bytes);
+function parseWorkbookStructureAssetsFromArchive(
+  archive: ArchiveEntries,
+  options?: ParseWorkbookStructureOptions
+): WorkbookStructureAssets & {
+  contentTypes: ContentTypesState;
+  theme: ThemeState;
+  workbookSheets: WorkbookSheetInfo[];
+} {
   const contentTypes = parseContentTypes(archive);
   const workbookSheets = parseWorkbookSheets(archive);
   const theme = parseWorkbookTheme(archive);
   const themePalette = buildThemePalette(theme);
   const { namedCellStyleByName, styleById, tableStyleByName } = parseWorkbookStyles(archive);
   const tableMetadataByWorkbookSheetIndex = parseWorkbookTableMetadata(archive, workbookSheets);
+  return {
+    contentTypes,
+    namedCellStyleByName,
+    sheetStatesByWorkbookSheetIndex: workbookSheets.map((sheet) => parseSheetState(archive, sheet.path, options)),
+    styleById,
+    tableMetadataByWorkbookSheetIndex,
+    tableStyleByName,
+    theme,
+    themePalette,
+    workbookSheets
+  };
+}
+
+export function parseWorkbookStructureAssets(
+  bytes: Uint8Array,
+  options?: ParseWorkbookStructureOptions
+): WorkbookStructureAssets {
+  const archive = unzipSync(bytes);
+  const {
+    namedCellStyleByName,
+    sheetStatesByWorkbookSheetIndex,
+    styleById,
+    tableMetadataByWorkbookSheetIndex,
+    tableStyleByName,
+    themePalette
+  } = parseWorkbookStructureAssetsFromArchive(archive, options);
+
+  return {
+    namedCellStyleByName,
+    sheetStatesByWorkbookSheetIndex,
+    styleById,
+    tableMetadataByWorkbookSheetIndex,
+    tableStyleByName,
+    themePalette
+  };
+}
+
+export function parseWorkbookImageAssets(bytes: Uint8Array): WorkbookImageAssets {
+  const archive = unzipSync(bytes);
+  const {
+    contentTypes,
+    namedCellStyleByName,
+    sheetStatesByWorkbookSheetIndex,
+    styleById,
+    tableMetadataByWorkbookSheetIndex,
+    tableStyleByName,
+    theme,
+    themePalette,
+    workbookSheets
+  } = parseWorkbookStructureAssetsFromArchive(archive);
   const objectUrls: string[] = [];
   const imagesByWorkbookSheetIndex: XlsxImage[][] = [];
   const shapesByWorkbookSheetIndex: XlsxShape[][] = [];
-  const sheetStatesByWorkbookSheetIndex: Array<WorkbookSheetState | null> = [];
   const sheetOrigins: Array<WorkbookImageSheetOrigin | null> = [];
   const imageOriginsById = new Map<string, WorkbookImageOrigin>();
 
@@ -2393,7 +2483,6 @@ export function parseWorkbookImageAssets(bytes: Uint8Array): WorkbookImageAssets
     const attachments: XlsxImageAttachment[] = [];
     const imageList: XlsxImage[] = [];
     const shapeList: XlsxShape[] = [];
-    sheetStatesByWorkbookSheetIndex[workbookSheetIndex] = parseSheetState(archive, sheet.path);
     let zIndexBase = 1;
 
     for (const relationship of sheetRelationships.values()) {

--- a/packages/react-xlsx/src/types.ts
+++ b/packages/react-xlsx/src/types.ts
@@ -76,6 +76,8 @@ export interface XlsxSheetData {
   cachedFormulaValues: Record<string, string>;
   colWidthOverridesPx: Record<number, number>;
   colStyleIds: Record<number, number>;
+  hiddenCols?: number[];
+  hiddenRows?: number[];
   conditionalFormatRules: XlsxConditionalFormatRule[];
   dataValidations: XlsxDataValidation[];
   name: string;
@@ -302,7 +304,9 @@ export interface UseXlsxViewerControllerOptions {
   file?: ArrayBuffer;
   fileName?: string;
   readOnly?: boolean;
+  readOnlyAboveBytes?: number;
   src?: string;
+  useWorker?: boolean;
 }
 
 export interface XlsxViewerController {
@@ -335,8 +339,13 @@ export interface XlsxViewerController {
   getClipboardData: () => XlsxClipboardData | null;
   getCellDisplayValue: (cell?: XlsxCellAddress | null) => string;
   getCellFormula: (cell?: XlsxCellAddress | null) => string;
+  getCellSnapshotAsync?: (workbookSheetIndex: number, row: number, col: number) => Promise<{
+    displayValue: string;
+    formula: string;
+  }>;
   isLoadDeferred: boolean;
   isLoading: boolean;
+  isWorkerBacked?: boolean;
   images: XlsxImage[];
   shapes: XlsxShape[];
   mergeSelection: () => void;
@@ -376,6 +385,7 @@ export interface XlsxViewerController {
   sortTable: (tableName: string, columnIndex: number, direction: XlsxTableSortDirection) => void;
   selectImage: (id: string | null) => void;
   setImageRect: (id: string, rect: XlsxImageRect) => void;
+  getRowsBatchAsync?: (workbookSheetIndex: number, startRow: number, rowCount: number) => Promise<unknown[] | null>;
   tables: XlsxTable[];
   undo: () => void;
   unmergeSelection: () => void;

--- a/packages/react-xlsx/src/worker-client.ts
+++ b/packages/react-xlsx/src/worker-client.ts
@@ -1,0 +1,150 @@
+import type { XlsxSheetData, XlsxTable } from "./types";
+
+type WorkerMessage =
+  | {
+      id: number;
+      type: "load";
+      payload: {
+        buffer: ArrayBuffer;
+      };
+    }
+  | {
+      id: number;
+      type: "getCellSnapshot";
+      payload: {
+        workbookSheetIndex: number;
+        row: number;
+        col: number;
+      };
+    }
+  | {
+      id: number;
+      type: "getRowsBatch";
+      payload: {
+        workbookSheetIndex: number;
+        startRow: number;
+        rowCount: number;
+      };
+    };
+
+type WorkerSuccessMessage =
+  | {
+      id: number;
+      success: true;
+      result: {
+        sheets: XlsxSheetData[];
+        tablesByWorkbookSheetIndex: XlsxTable[][];
+      };
+    }
+  | {
+      id: number;
+      success: true;
+      result: {
+        displayValue: string;
+        formula: string;
+      };
+    }
+  | {
+      id: number;
+      success: true;
+      result: unknown[] | null;
+    };
+
+type WorkerErrorMessage = {
+  id: number;
+  success: false;
+  error: string;
+};
+
+type WorkerResponse = WorkerSuccessMessage | WorkerErrorMessage;
+
+type PendingRequest = {
+  reject: (error: Error) => void;
+  resolve: (value: unknown) => void;
+};
+
+export class XlsxWorkerClient {
+  private readonly worker: Worker;
+
+  private nextRequestId = 1;
+
+  private readonly pendingRequests = new Map<number, PendingRequest>();
+
+  constructor() {
+    this.worker = new Worker(new URL("./xlsx-worker.js", import.meta.url), { type: "module" });
+    this.worker.addEventListener("message", this.handleMessage);
+    this.worker.addEventListener("error", this.handleError);
+  }
+
+  dispose() {
+    this.worker.removeEventListener("message", this.handleMessage);
+    this.worker.removeEventListener("error", this.handleError);
+    this.worker.terminate();
+    for (const request of this.pendingRequests.values()) {
+      request.reject(new Error("Worker was disposed."));
+    }
+    this.pendingRequests.clear();
+  }
+
+  loadWorkbook(buffer: ArrayBuffer) {
+    return this.request<{
+      sheets: XlsxSheetData[];
+      tablesByWorkbookSheetIndex: XlsxTable[][];
+    }>({
+      id: 0,
+      payload: { buffer },
+      type: "load"
+    }, [buffer]);
+  }
+
+  getCellSnapshot(workbookSheetIndex: number, row: number, col: number) {
+    return this.request<{
+      displayValue: string;
+      formula: string;
+    }>({
+      id: 0,
+      payload: { col, row, workbookSheetIndex },
+      type: "getCellSnapshot"
+    });
+  }
+
+  getRowsBatch(workbookSheetIndex: number, startRow: number, rowCount: number) {
+    return this.request<unknown[] | null>({
+      id: 0,
+      payload: { rowCount, startRow, workbookSheetIndex },
+      type: "getRowsBatch"
+    });
+  }
+
+  private request<TResult>(message: WorkerMessage, transfer: Transferable[] = []) {
+    return new Promise<TResult>((resolve, reject) => {
+      const id = this.nextRequestId;
+      this.nextRequestId += 1;
+      this.pendingRequests.set(id, { reject, resolve: resolve as (value: unknown) => void });
+      this.worker.postMessage({ ...message, id }, transfer);
+    });
+  }
+
+  private readonly handleError = () => {
+    for (const request of this.pendingRequests.values()) {
+      request.reject(new Error("Worker request failed."));
+    }
+    this.pendingRequests.clear();
+  };
+
+  private readonly handleMessage = (event: MessageEvent<WorkerResponse>) => {
+    const message = event.data;
+    const request = this.pendingRequests.get(message.id);
+    if (!request) {
+      return;
+    }
+
+    this.pendingRequests.delete(message.id);
+    if (!message.success) {
+      request.reject(new Error(message.error));
+      return;
+    }
+
+    request.resolve(message.result);
+  };
+}

--- a/packages/react-xlsx/src/xlsx-worker.js
+++ b/packages/react-xlsx/src/xlsx-worker.js
@@ -1,0 +1,1 @@
+import "./xlsx-worker.ts";

--- a/packages/react-xlsx/src/xlsx-worker.ts
+++ b/packages/react-xlsx/src/xlsx-worker.ts
@@ -1,0 +1,470 @@
+import type { Workbook } from "@dukelib/sheets-wasm";
+import { parseWorkbookStructureAssets, resolveSheetColumnWidthPixels } from "./images";
+import type { WorkbookStructureAssets } from "./images";
+import { getSheetsWasmModule } from "./wasm";
+import type {
+  XlsxCellAddress,
+  XlsxCellRange,
+  XlsxDataValidation,
+  XlsxFreezePanes,
+  XlsxResolvedCellStyle,
+  XlsxSheetData,
+  XlsxTable,
+  XlsxTableStyleDefinition
+} from "./types";
+
+const DEFAULT_ROW_HEIGHT = 24;
+const DEFAULT_COL_WIDTH = 80;
+const FORMULA_COUNT_THRESHOLD = 1000;
+const FAST_STRUCTURE_PARSE_THRESHOLD_BYTES = 5 * 1024 * 1024;
+
+type WorkerRequest =
+  | {
+      id: number;
+      type: "load";
+      payload: {
+        buffer: ArrayBuffer;
+      };
+    }
+  | {
+      id: number;
+      type: "getCellSnapshot";
+      payload: {
+        workbookSheetIndex: number;
+        row: number;
+        col: number;
+      };
+    }
+  | {
+      id: number;
+      type: "getRowsBatch";
+      payload: {
+        workbookSheetIndex: number;
+        startRow: number;
+        rowCount: number;
+      };
+    };
+
+type WorkerSuccessResponse = {
+  id: number;
+  success: true;
+  result:
+    | {
+        sheets: XlsxSheetData[];
+        tablesByWorkbookSheetIndex: XlsxTable[][];
+      }
+    | {
+        displayValue: string;
+        formula: string;
+      }
+    | unknown[]
+    | null;
+};
+
+type WorkerErrorResponse = {
+  id: number;
+  success: false;
+  error: string;
+};
+
+type WorkerResponse = WorkerSuccessResponse | WorkerErrorResponse;
+
+let workbook: Workbook | null = null;
+let sheets: XlsxSheetData[] = [];
+let tablesByWorkbookSheetIndex: XlsxTable[][] = [];
+
+function normalizeRange(range: XlsxCellRange): XlsxCellRange {
+  return {
+    start: {
+      col: Math.min(range.start.col, range.end.col),
+      row: Math.min(range.start.row, range.end.row)
+    },
+    end: {
+      col: Math.max(range.start.col, range.end.col),
+      row: Math.max(range.start.row, range.end.row)
+    }
+  };
+}
+
+function parseA1CellReference(reference: string): XlsxCellAddress | null {
+  const match = /^([A-Z]+)(\d+)$/i.exec(reference.trim());
+  if (!match) {
+    return null;
+  }
+
+  const [, columnPart, rowPart] = match;
+  let col = 0;
+  for (const char of columnPart.toUpperCase()) {
+    col = col * 26 + (char.charCodeAt(0) - 64);
+  }
+
+  return {
+    col: col - 1,
+    row: Number(rowPart) - 1
+  };
+}
+
+function parseA1RangeReference(reference: string): XlsxCellRange | null {
+  const [startRef, endRef = startRef] = reference.split(":");
+  const start = parseA1CellReference(startRef ?? "");
+  const end = parseA1CellReference(endRef ?? "");
+  if (!start || !end) {
+    return null;
+  }
+
+  return normalizeRange({ end, start });
+}
+
+function parseWorksheetFreezePanes(worksheet: ReturnType<Workbook["getSheet"]>): XlsxFreezePanes | null {
+  const rawFreezePanes = worksheet.freezePanes as Record<string, unknown> | null | undefined;
+  const row = typeof rawFreezePanes?.row === "number" && rawFreezePanes.row >= 0 ? rawFreezePanes.row : null;
+  const col = typeof rawFreezePanes?.col === "number" && rawFreezePanes.col >= 0 ? rawFreezePanes.col : null;
+  if (row === null && col === null) {
+    return null;
+  }
+
+  return {
+    col: col ?? 0,
+    row: row ?? 0
+  };
+}
+
+function parseWorksheetDataValidations(worksheet: ReturnType<Workbook["getSheet"]>): XlsxDataValidation[] {
+  const rawDataValidations = Array.isArray(worksheet.dataValidations) ? worksheet.dataValidations : [];
+
+  return rawDataValidations.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+
+    const validation = entry as Record<string, unknown>;
+    const ranges = Array.isArray(validation.ranges)
+      ? validation.ranges.flatMap((range) => {
+          if (typeof range !== "string") {
+            return [];
+          }
+
+          const parsedRange = parseA1RangeReference(range);
+          return parsedRange ? [parsedRange] : [];
+        })
+      : [];
+    const validationType = typeof validation.validationType === "string" ? validation.validationType : null;
+    if (!validationType || ranges.length === 0) {
+      return [];
+    }
+
+    return [{
+      allowBlank: typeof validation.allowBlank === "boolean" ? validation.allowBlank : undefined,
+      errorMessage: typeof validation.errorMessage === "string" ? validation.errorMessage : undefined,
+      errorStyle: typeof validation.errorStyle === "string" ? validation.errorStyle : undefined,
+      inputMessage: typeof validation.inputMessage === "string" ? validation.inputMessage : undefined,
+      listSource: typeof validation.listSource === "string" ? validation.listSource : undefined,
+      ranges,
+      showDropdown: typeof validation.showDropdown === "boolean" ? validation.showDropdown : undefined,
+      showErrorAlert: typeof validation.showErrorAlert === "boolean" ? validation.showErrorAlert : undefined,
+      showInputMessage: typeof validation.showInputMessage === "boolean" ? validation.showInputMessage : undefined,
+      validationType
+    } satisfies XlsxDataValidation];
+  });
+}
+
+function buildSheetList(
+  nextWorkbook: Workbook,
+  structureAssets?: WorkbookStructureAssets | null
+) {
+  const sheetsByWorkbookSheetIndex: XlsxSheetData[] = [];
+
+  for (let index = 0; index < nextWorkbook.sheetCount; index += 1) {
+    const worksheet = nextWorkbook.getSheet(index);
+    const sheetState = structureAssets?.sheetStatesByWorkbookSheetIndex[index] ?? null;
+    if (worksheet.visibility !== "visible") {
+      continue;
+    }
+
+    const resolveColumnWidthPx = (col: number) => {
+      const width = worksheet.getColumnWidth(col);
+      if (width !== undefined && width !== null) {
+        return resolveSheetColumnWidthPixels(width);
+      }
+
+      return sheetState?.colWidthOverridesPx?.[col] ?? sheetState?.defaultColWidthPx ?? DEFAULT_COL_WIDTH;
+    };
+
+    const resolveRowHeightPx = (row: number) => {
+      const height = worksheet.getRowHeight(row);
+      if (height !== undefined && height !== null) {
+        return Math.max(Math.round(height * 1.33), 16);
+      }
+
+      return sheetState?.rowHeightOverridesPx?.[row] ?? sheetState?.defaultRowHeightPx ?? DEFAULT_ROW_HEIGHT;
+    };
+
+    const usedRange = worksheet.usedRange() as [number, number, number, number] | null;
+    if (!usedRange) {
+      sheetsByWorkbookSheetIndex.push({
+        cachedFormulaValues: sheetState?.cachedFormulaValues ?? {},
+        colCount: 0,
+        colStyleIds: sheetState?.colStyleIds ?? {},
+        colWidthOverridesPx: sheetState?.colWidthOverridesPx ?? {},
+        colWidths: [],
+        conditionalFormatRules: sheetState?.conditionalFormatRules ?? [],
+        dataValidations: parseWorksheetDataValidations(worksheet),
+        defaultColWidthPx: sheetState?.defaultColWidthPx ?? DEFAULT_COL_WIDTH,
+        defaultRowHeightPx: sheetState?.defaultRowHeightPx ?? DEFAULT_ROW_HEIGHT,
+        freezePanes: parseWorksheetFreezePanes(worksheet),
+        hasHorizontalMerges: sheetState?.hasHorizontalMerges ?? false,
+        hasVerticalMerges: sheetState?.hasVerticalMerges ?? false,
+        hiddenCols: sheetState?.hiddenCols ?? [],
+        hiddenRows: sheetState?.hiddenRows ?? [],
+        maxUsedCol: -1,
+        maxUsedRow: -1,
+        name: worksheet.name,
+        namedCellStyleByName: structureAssets?.namedCellStyleByName ?? {},
+        rowCount: 0,
+        rowHeightOverridesPx: sheetState?.rowHeightOverridesPx ?? {},
+        rowHeights: [],
+        rowStyleIds: sheetState?.rowStyleIds ?? {},
+        showGridLines: sheetState?.showGridLines ?? true,
+        styleById: structureAssets?.styleById ?? {},
+        tableStyleByName: structureAssets?.tableStyleByName ?? {},
+        themePalette: structureAssets?.themePalette ?? { colorsByIndex: {} },
+        visibleCols: [],
+        visibleRows: [],
+        workbookSheetIndex: index,
+        zoomScale: typeof worksheet.zoomScale === "number" ? worksheet.zoomScale : undefined
+      });
+      continue;
+    }
+
+    const [, , maxRow, maxCol] = usedRange;
+    const hiddenRows = (sheetState?.hiddenRows ?? []).filter((row) => row >= 0 && row <= maxRow);
+    const hiddenCols = (sheetState?.hiddenCols ?? []).filter((col) => col >= 0 && col <= maxCol);
+
+    sheetsByWorkbookSheetIndex.push({
+      cachedFormulaValues: sheetState?.cachedFormulaValues ?? {},
+      colCount: Math.max(0, maxCol + 1 - hiddenCols.length),
+      colStyleIds: sheetState?.colStyleIds ?? {},
+      colWidthOverridesPx: sheetState?.colWidthOverridesPx ?? {},
+      colWidths: [],
+      conditionalFormatRules: sheetState?.conditionalFormatRules ?? [],
+      dataValidations: parseWorksheetDataValidations(worksheet),
+      defaultColWidthPx: sheetState?.defaultColWidthPx ?? DEFAULT_COL_WIDTH,
+      defaultRowHeightPx: sheetState?.defaultRowHeightPx ?? DEFAULT_ROW_HEIGHT,
+      freezePanes: parseWorksheetFreezePanes(worksheet),
+      hasHorizontalMerges: sheetState?.hasHorizontalMerges ?? false,
+      hasVerticalMerges: sheetState?.hasVerticalMerges ?? false,
+      hiddenCols,
+      hiddenRows,
+      maxUsedCol: maxCol,
+      maxUsedRow: maxRow,
+      name: worksheet.name,
+      namedCellStyleByName: structureAssets?.namedCellStyleByName ?? {},
+      rowCount: Math.max(0, maxRow + 1 - hiddenRows.length),
+      rowHeightOverridesPx: sheetState?.rowHeightOverridesPx ?? {},
+      rowHeights: [],
+      rowStyleIds: sheetState?.rowStyleIds ?? {},
+      showGridLines: sheetState?.showGridLines ?? true,
+      styleById: structureAssets?.styleById ?? {},
+      tableStyleByName: structureAssets?.tableStyleByName ?? {},
+      themePalette: structureAssets?.themePalette ?? { colorsByIndex: {} },
+      visibleCols: [],
+      visibleRows: [],
+      workbookSheetIndex: index,
+      zoomScale: typeof worksheet.zoomScale === "number" ? worksheet.zoomScale : undefined
+    });
+  }
+
+  return sheetsByWorkbookSheetIndex;
+}
+
+function mapWorksheetTables(
+  worksheet: ReturnType<Workbook["getSheet"]> | null,
+  metadataForSheet?: ReturnType<typeof parseWorkbookStructureAssets>["tableMetadataByWorkbookSheetIndex"][number] | null
+): XlsxTable[] {
+  const rawTables = (worksheet?.tables ?? []) as Array<Record<string, unknown>>;
+  return rawTables.flatMap((table, index) => {
+    const reference = typeof table.reference === "string" ? table.reference : "";
+    const parsedRange = parseA1RangeReference(reference);
+    if (!parsedRange) {
+      return [];
+    }
+
+    const rawColumns = Array.isArray(table.columns) ? table.columns : [];
+    const rawName = typeof table.name === "string" ? table.name : `Table${index + 1}`;
+    const rawDisplayName =
+      typeof table.displayName === "string"
+        ? table.displayName
+        : typeof table.name === "string"
+          ? table.name
+          : `Table ${index + 1}`;
+    const metadata = metadataForSheet?.find((entry) =>
+      (entry.name && entry.name === rawName)
+      || (entry.displayName && entry.displayName === rawDisplayName)
+      || (entry.reference && entry.reference === reference)
+    );
+
+    return [{
+      columns: rawColumns.map((column, columnIndex) => ({
+        id: typeof (column as { id?: unknown }).id === "number" ? ((column as { id?: number }).id ?? columnIndex + 1) : columnIndex + 1,
+        index: columnIndex,
+        name: typeof (column as { name?: unknown }).name === "string" ? ((column as { name?: string }).name ?? `Column ${columnIndex + 1}`) : `Column ${columnIndex + 1}`
+      })),
+      displayName: rawDisplayName,
+      end: parsedRange.end,
+      headerRowCount: typeof table.headerRowCount === "number" ? table.headerRowCount : 1,
+      headerRowCellStyle: metadata?.headerRowCellStyle,
+      name: rawName,
+      reference,
+      start: parsedRange.start,
+      styleInfo: table.styleInfo as XlsxTable["styleInfo"] | undefined,
+      totalsRowCount: typeof table.totalsRowCount === "number" ? table.totalsRowCount : 0,
+      totalsRowShown: Boolean(table.totalsRowShown)
+    }];
+  });
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&quot;/g, "\"")
+    .replace(/&#34;/g, "\"")
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function getCellDisplayValue(worksheet: ReturnType<Workbook["getSheet"]>, row: number, col: number, activeSheet?: XlsxSheetData | null) {
+  const formula = worksheet.getFormulaAt(row, col);
+  const cachedFormulaValue = formula ? activeSheet?.cachedFormulaValues?.[cellAddressToA1({ row, col })] : undefined;
+  const formatted = worksheet.getFormattedValueAt(row, col);
+  if (formatted && !(formula && cachedFormulaValue !== undefined && formatted.startsWith("#"))) {
+    return decodeHtmlEntities(formatted);
+  }
+
+  const cellValue = worksheet.getCalculatedValueAt(row, col);
+  if (formula && cachedFormulaValue !== undefined && cellValue.is_error) {
+    return cachedFormulaValue;
+  }
+  if (cellValue.is_error) {
+    return cellValue.asError() ?? "";
+  }
+  if (cellValue.is_empty) {
+    return "";
+  }
+
+  return cellValue.toString();
+}
+
+function cellAddressToA1(cell: XlsxCellAddress) {
+  let col = cell.col + 1;
+  let label = "";
+  while (col > 0) {
+    const remainder = (col - 1) % 26;
+    label = String.fromCharCode(65 + remainder) + label;
+    col = Math.floor((col - 1) / 26);
+  }
+  return `${label}${cell.row + 1}`;
+}
+
+async function loadWorkbook(buffer: ArrayBuffer) {
+  const wasmModule = await getSheetsWasmModule();
+  const bytes = new Uint8Array(buffer);
+  const nextWorkbook = wasmModule.Workbook.fromBytes(bytes);
+  let totalFormulas = 0;
+  for (let index = 0; index < nextWorkbook.sheetCount; index += 1) {
+    totalFormulas += nextWorkbook.getSheet(index).formulaCount;
+  }
+
+  if (totalFormulas <= FORMULA_COUNT_THRESHOLD) {
+    nextWorkbook.calculate();
+  }
+
+  const shouldUseFastStructureParse =
+    bytes.byteLength >= FAST_STRUCTURE_PARSE_THRESHOLD_BYTES && totalFormulas <= FORMULA_COUNT_THRESHOLD;
+  const structureAssets = shouldUseFastStructureParse
+    ? null
+    : parseWorkbookStructureAssets(bytes, {
+        includeCachedFormulaValues: true
+      });
+  workbook = nextWorkbook;
+  sheets = buildSheetList(nextWorkbook, structureAssets);
+  tablesByWorkbookSheetIndex = Array.from({ length: nextWorkbook.sheetCount }, (_, workbookSheetIndex) =>
+    mapWorksheetTables(
+      nextWorkbook.getSheet(workbookSheetIndex),
+      structureAssets?.tableMetadataByWorkbookSheetIndex[workbookSheetIndex] ?? null
+    )
+  );
+  return {
+    sheets,
+    tablesByWorkbookSheetIndex
+  };
+}
+
+function respond(message: WorkerResponse) {
+  self.postMessage(message);
+}
+
+async function handleMessage(message: WorkerRequest) {
+  switch (message.type) {
+    case "load": {
+      return loadWorkbook(message.payload.buffer);
+    }
+    case "getCellSnapshot": {
+      if (!workbook) {
+        return {
+          displayValue: "",
+          formula: ""
+        };
+      }
+
+      const targetSheet = sheets.find((sheet) => sheet.workbookSheetIndex === message.payload.workbookSheetIndex) ?? null;
+      const worksheet = workbook.getSheet(message.payload.workbookSheetIndex);
+      return {
+        displayValue: getCellDisplayValue(worksheet, message.payload.row, message.payload.col, targetSheet),
+        formula: worksheet.getFormulaAt(message.payload.row, message.payload.col) ?? ""
+      };
+    }
+    case "getRowsBatch": {
+      if (!workbook) {
+        return null;
+      }
+
+      const worksheet = workbook.getSheet(message.payload.workbookSheetIndex) as ReturnType<Workbook["getSheet"]> & {
+        getRowsBatch?: (startRow: number, maxRows: number, options?: unknown) => unknown;
+      };
+      if (typeof worksheet.getRowsBatch !== "function") {
+        return null;
+      }
+
+      return worksheet.getRowsBatch(message.payload.startRow, message.payload.rowCount, {
+        includeFormulas: true,
+        includeHyperlinks: true,
+        includeMergeInfo: true,
+        includeStyles: true,
+        useFormattedValues: true
+      }) as unknown[] | null;
+    }
+    default:
+      return null;
+  }
+}
+
+self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
+  const message = event.data;
+  void handleMessage(message)
+    .then((result) => {
+      respond({
+        id: message.id,
+        result,
+        success: true
+      });
+    })
+    .catch((error: unknown) => {
+      respond({
+        error: error instanceof Error ? error.message : "Worker request failed.",
+        id: message.id,
+        success: false
+      } satisfies WorkerErrorResponse);
+    });
+});


### PR DESCRIPTION
## Summary
- add large-workbook safeguards to force read-only/worker paths and show a placeholder when XLSX internals are too large for interactive preview
- optimize worker-side workbook loading for large sheets by skipping expensive parsing paths when possible
- update viewer rendering for freeze panes, drawing/image positioning, and gridline alignment, including darker-mode separator tuning
- add the new large-file threshold wiring to the playground for easier manual verification

## Testing
- `pnpm --filter react-xlsx typecheck`
- `pnpm --filter react-xlsx build`