### PR TITLE
Add getCellStyle escape hatch for custom per-cell styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ export function WorkbookWorkspace({ buffer }: { buffer: ArrayBuffer }) {
 | Prop | Type | Notes |
 | --- | --- | --- |
 | `emptyState` | `React.ReactNode` | Rendered when no workbook is loaded. |
+| `getCellStyle` | `(context: XlsxCellStyleContext) => React.CSSProperties \| null \| undefined` | Returns extra CSS overrides merged on top of each cell's resolved style. Escape hatch for custom per-cell styling (highlights, outlines, status tints) without forking workbook data. See [Custom Cell Styling](#custom-cell-styling). |
 | `loadingComponent` | `React.ReactElement` | Full loading replacement component. |
 | `loadingState` | `React.ReactNode` | Loading fallback content. |
 | `errorState` | `React.ReactNode \| (error: Error) => React.ReactNode` | Custom error UI. |
@@ -162,6 +163,55 @@ Notes:
 - This render prop is intended for returning the full trigger and menu tree, not just menu items
 - In the default DOM renderer, your returned node replaces the built-in chevron trigger in the table header cell
 - `experimentalCanvas` still uses the built-in canvas affordance for table header menus
+
+## Custom Cell Styling
+
+`getCellStyle` is an escape hatch for styling individual cells without forking the workbook data. The viewer calls it for every rendered cell and merges the returned partial style on top of the cell's resolved style. Return `undefined` (or `null`) to leave a cell untouched.
+
+```tsx
+import * as React from "react";
+import { XlsxViewer, type XlsxViewerProps } from "@extend-ai/react-xlsx";
+
+function Workbook({ buffer, highlighted }: { buffer: ArrayBuffer; highlighted: Set<string> }) {
+  const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+    ({ cell, isTableHeader }) => {
+      if (isTableHeader) {
+        return undefined;
+      }
+      if (highlighted.has(`${cell.row}:${cell.col}`)) {
+        return { backgroundColor: "rgba(37, 99, 235, 0.12)", outline: "1px solid #2563eb" };
+      }
+      return undefined;
+    },
+    [highlighted]
+  );
+
+  return <XlsxViewer file={buffer} getCellStyle={getCellStyle} />;
+}
+```
+
+The `context` argument is an `XlsxCellStyleContext`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `cell` | `XlsxCellAddress` | Address of the cell being styled. |
+| `workbookSheetIndex` | `number` | Workbook sheet index of the cell's sheet. |
+| `sheetName` | `string` | Display name of the cell's sheet. |
+| `resolvedStyle` | `React.CSSProperties` | The style the viewer computed (workbook formatting + built-ins). Read-only. |
+| `value` | `string` | The cell's resolved display value. |
+| `hasValidation` | `boolean` | Cell has a data validation rule. |
+| `hasHyperlink` | `boolean` | Cell has a hyperlink. |
+| `hasConditionalFormat` | `boolean` | Cell is affected by a color scale, data bar, or icon set. |
+| `hasChartHighlight` | `boolean` | Cell is in a selected chart's highlighted source range. |
+| `isMerged` | `boolean` | Cell is the anchor of a merged range. |
+| `isTableHeader` | `boolean` | Cell is a table header cell. |
+
+Notes:
+
+- Keep the callback stable (e.g. wrap it in `useCallback`) so cell styling is not recomputed on every render. When the callback identity changes, the viewer re-resolves and repaints cells.
+- The DOM renderer (`experimentalCanvas={false}`) applies every returned CSS property.
+- The canvas renderer (the default) honors the subset it can paint: `backgroundColor`, `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`, `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`, `outline`, or `animation` apply in the DOM renderer.
+- `getCellStyle` is not applied to worksheet thumbnails painted via `useXlsxViewerThumbnails(...)`.
 
 ## `XlsxViewerProvider` Props
 
@@ -310,7 +360,7 @@ The package also exports the main types you are likely to use for custom integra
 - `XlsxImage`, `XlsxImageRect`, `XlsxImageRenderProps`, `XlsxImageSelectionRenderProps`
 - `XlsxSheetThumbnail`, `XlsxSheetThumbnailResolution`
 - `XlsxTable`, `XlsxTableColumn`, `XlsxTableHeaderMenuRenderProps`
-- `XlsxWorkbookTab`, `XlsxCellAddress`, `XlsxCellRange`
+- `XlsxWorkbookTab`, `XlsxCellAddress`, `XlsxCellRange`, `XlsxCellStyleContext`
 
 ## Notes
 

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -7,7 +7,8 @@ import {
   useXlsxViewerThumbnails,
   useXlsxViewerZoom,
   XlsxViewer,
-  XlsxViewerProvider
+  XlsxViewerProvider,
+  type XlsxViewerProps
 } from "@extend-ai/react-xlsx";
 import { Button } from "./components/ui/button";
 import { ButtonGroup } from "./components/ui/button-group";
@@ -93,6 +94,7 @@ function ViewerFileTooLargeState() {
 
 function WorkbookToolbar({
   experimentalCanvas,
+  highlightCells,
   isDocumentDark,
   onClear,
   onLoadExampleUrl,
@@ -101,11 +103,13 @@ function WorkbookToolbar({
   readOnly,
   remoteUrl,
   setExperimentalCanvas,
+  setHighlightCells,
   setIsDocumentDark,
   setReadOnly,
   setRemoteUrl,
 }: {
   experimentalCanvas: boolean;
+  highlightCells: boolean;
   isDocumentDark: boolean;
   onClear: () => void;
   onLoadExampleUrl: () => void;
@@ -114,6 +118,7 @@ function WorkbookToolbar({
   readOnly: boolean;
   remoteUrl: string;
   setExperimentalCanvas: (value: boolean) => void;
+  setHighlightCells: (value: boolean) => void;
   setIsDocumentDark: (value: boolean) => void;
   setReadOnly: (value: boolean) => void;
   setRemoteUrl: (value: string) => void;
@@ -237,6 +242,15 @@ function WorkbookToolbar({
               aria-label="Toggle read only mode"
               checked={isReadOnly}
               onCheckedChange={setReadOnly}
+              size="sm"
+            />
+          </div>
+          <div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
+            <span className="text-muted-foreground text-[11px] font-medium">Highlight</span>
+            <Switch
+              aria-label="Toggle custom cell highlighting via getCellStyle"
+              checked={highlightCells}
+              onCheckedChange={setHighlightCells}
               size="sm"
             />
           </div>
@@ -537,7 +551,21 @@ export function App() {
   const [isDocumentDark, setIsDocumentDark] = React.useState(false);
   const [experimentalCanvas, setExperimentalCanvas] = React.useState(true);
   const [isReadOnly, setIsReadOnly] = React.useState(true);
+  const [highlightCells, setHighlightCells] = React.useState(false);
   const dragDepthRef = React.useRef(0);
+
+  const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+    ({ cell, isTableHeader }) => {
+      if (!highlightCells || isTableHeader) {
+        return undefined;
+      }
+      if (cell.row % 2 === 1) {
+        return { backgroundColor: isDocumentDark ? "rgba(56, 189, 248, 0.16)" : "rgba(37, 99, 235, 0.08)" };
+      }
+      return undefined;
+    },
+    [highlightCells, isDocumentDark]
+  );
 
   const controller = useXlsxViewerController(
     source?.type === "file"
@@ -708,6 +736,7 @@ export function App() {
           <XlsxViewerProvider controller={controller} isDark={isDocumentDark}>
             <WorkbookToolbar
               experimentalCanvas={experimentalCanvas}
+              highlightCells={highlightCells}
               isDocumentDark={isDocumentDark}
               onClear={handleClear}
               onLoadExampleUrl={handleLoadExampleUrl}
@@ -716,6 +745,7 @@ export function App() {
               readOnly={isReadOnly}
               remoteUrl={remoteUrl}
               setExperimentalCanvas={setExperimentalCanvas}
+              setHighlightCells={setHighlightCells}
               setIsDocumentDark={setIsDocumentDark}
               setReadOnly={setIsReadOnly}
               setRemoteUrl={setRemoteUrl}
@@ -726,6 +756,7 @@ export function App() {
                   className="h-full min-h-0 min-w-0 flex-1"
                   emptyState={<ViewerEmptyState />}
                   fileTooLargeState={<ViewerFileTooLargeState />}
+                  getCellStyle={getCellStyle}
                   height="100%"
                   allowResizeInReadOnly
                   isDark={isDocumentDark}

--- a/packages/react-xlsx/README.md
+++ b/packages/react-xlsx/README.md
@@ -344,11 +344,60 @@ Common rendering props:
 - `loadingState?: React.ReactNode`
 - `errorState?: React.ReactNode | ((error: Error) => React.ReactNode)`
 - `fileTooLargeState?: React.ReactNode | ((props: XlsxFileTooLargeRenderProps) => React.ReactNode)`
+- `getCellStyle?: (context: XlsxCellStyleContext) => React.CSSProperties | null | undefined`
 - `renderImage?: (props: XlsxImageRenderProps) => React.ReactNode`
 - `renderImageSelection?: (props: XlsxImageSelectionRenderProps) => React.ReactNode`
 - `renderChartLoading?: (props: XlsxChartLoadingRenderProps) => React.ReactNode`
 - `renderTableHeaderMenu?: (props: XlsxTableHeaderMenuRenderProps) => React.ReactNode`
 - `renderScroller?: (props: XlsxScrollerRenderProps) => React.ReactNode`
+
+### Custom Cell Styling
+
+`getCellStyle` is an escape hatch for styling individual cells without forking the workbook data. It is called for every rendered cell and returns a partial `React.CSSProperties` that merges on top of the viewer's resolved style. Return `undefined` (or `null`) to leave a cell untouched.
+
+```tsx
+import { XlsxViewer, type XlsxViewerProps } from "@extend-ai/react-xlsx";
+
+function Workbook({ buffer, highlighted }: { buffer: ArrayBuffer; highlighted: Set<string> }) {
+  const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+    ({ cell, isTableHeader }) => {
+      if (isTableHeader) {
+        return undefined;
+      }
+      if (highlighted.has(`${cell.row}:${cell.col}`)) {
+        return { backgroundColor: "rgba(37, 99, 235, 0.12)", outline: "1px solid #2563eb" };
+      }
+      return undefined;
+    },
+    [highlighted]
+  );
+
+  return <XlsxViewer file={buffer} getCellStyle={getCellStyle} />;
+}
+```
+
+The `context` passed to `getCellStyle` is an `XlsxCellStyleContext`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `cell` | `XlsxCellAddress` | Address of the cell being styled. |
+| `workbookSheetIndex` | `number` | Workbook sheet index of the cell's sheet. |
+| `sheetName` | `string` | Display name of the cell's sheet. |
+| `resolvedStyle` | `React.CSSProperties` | The style the viewer computed (workbook formatting + built-ins). Read-only. |
+| `value` | `string` | The cell's resolved display value. |
+| `hasValidation` | `boolean` | Cell has a data validation rule. |
+| `hasHyperlink` | `boolean` | Cell has a hyperlink. |
+| `hasConditionalFormat` | `boolean` | Cell is affected by a color scale, data bar, or icon set. |
+| `hasChartHighlight` | `boolean` | Cell is in a selected chart's highlighted source range. |
+| `isMerged` | `boolean` | Cell is the anchor of a merged range. |
+| `isTableHeader` | `boolean` | Cell is a table header cell. |
+
+Notes:
+
+- Keep the callback stable (e.g. `useCallback`) so cell styling is not recomputed every render. When the callback identity changes, the viewer re-resolves and repaints cells.
+- The DOM renderer (`experimentalCanvas={false}`) applies every returned CSS property.
+- The canvas renderer (the default) honors the subset it can paint: `backgroundColor`, `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`, `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`, `outline`, or `animation` apply in the DOM renderer.
+- `getCellStyle` is not applied to worksheet thumbnails painted via `useXlsxViewerThumbnails(...)`.
 
 ### Custom Scroll Area
 
@@ -415,6 +464,7 @@ The package exports the main types you are likely to use for custom integrations
 - `XlsxViewerCharts`
 - `XlsxViewerThumbnails`
 - `XlsxScrollerRenderProps`
+- `XlsxCellStyleContext`
 - `XlsxSheetThumbnail`
 - `UseXlsxViewerThumbnailsOptions`
 - `XlsxChart`, `XlsxChartSeries`, `XlsxChartAxis`, `XlsxChartsheet`

--- a/packages/react-xlsx/src/XlsxViewer.tsx
+++ b/packages/react-xlsx/src/XlsxViewer.tsx
@@ -8984,6 +8984,17 @@ function XlsxGrid({
       });
       if (styleOverrides) {
         nextData.style = { ...nextData.style, ...styleOverrides };
+        // getCellStyle is the final styling layer, so a host-provided
+        // background replaces the cell's background fill — including a
+        // conditional color-scale fill, since both target the full-cell
+        // background. Data bars and icon sets are overlays drawn on top and
+        // are intentionally left intact.
+        if (
+          nextData.conditionalColorScale &&
+          (styleOverrides.backgroundColor !== undefined || styleOverrides.background !== undefined)
+        ) {
+          nextData.conditionalColorScale = null;
+        }
       }
     }
 

--- a/packages/react-xlsx/src/XlsxViewer.tsx
+++ b/packages/react-xlsx/src/XlsxViewer.tsx
@@ -6393,6 +6393,7 @@ function XlsxGrid({
   enableCanvasSelectionAnimation = true,
   errorState,
   fileTooLargeState,
+  getCellStyle,
   loadingComponent,
   loadingState,
   renderChartLoading,
@@ -6409,7 +6410,7 @@ function XlsxGrid({
   showImages = true
 }: Pick<
   XlsxViewerProps,
-  "allowResizeInReadOnly" | "emptyState" | "enableCanvasSelectionAnimation" | "enableGestureZoom" | "errorState" | "experimentalCanvas" | "fileTooLargeState" | "loadingComponent" | "loadingState" | "renderChartLoading" | "renderImage" | "renderImageSelection" | "renderScroller" | "renderTableHeaderMenu" | "selectionColor" | "selectionFillColor" | "selectionHeaderColor" | "showImages"
+  "allowResizeInReadOnly" | "emptyState" | "enableCanvasSelectionAnimation" | "enableGestureZoom" | "errorState" | "experimentalCanvas" | "fileTooLargeState" | "getCellStyle" | "loadingComponent" | "loadingState" | "renderChartLoading" | "renderImage" | "renderImageSelection" | "renderScroller" | "renderTableHeaderMenu" | "selectionColor" | "selectionFillColor" | "selectionHeaderColor" | "showImages"
 > & {
   controller: XlsxViewerController;
   palette: ViewerPalette;
@@ -8798,7 +8799,7 @@ function XlsxGrid({
 
   React.useEffect(() => {
     cellRenderCacheRef.current.clear();
-  }, [activeSheetIndex, displayColLimit, displayRowLimit, palette, revision, viewportRowBatch, worksheet, zoomFactor]);
+  }, [activeSheetIndex, displayColLimit, displayRowLimit, getCellStyle, palette, revision, viewportRowBatch, worksheet, zoomFactor]);
 
   React.useEffect(() => {
     setAsyncViewportRowBatch(null);
@@ -8965,6 +8966,27 @@ function XlsxGrid({
             : getCellDisplayValue(worksheet, row, col, activeSheet)
     };
 
+    if (getCellStyle) {
+      const styleOverrides = getCellStyle({
+        cell: { row, col },
+        hasChartHighlight: Boolean(nextData.chartHighlight),
+        hasConditionalFormat: Boolean(
+          nextData.conditionalColorScale || nextData.conditionalDataBar || nextData.conditionalIcon
+        ),
+        hasHyperlink: Boolean(nextData.hyperlink),
+        hasValidation: Boolean(nextData.validation),
+        isMerged: Boolean(nextData.colSpan || nextData.rowSpan),
+        isTableHeader: Boolean(nextData.isTableHeader),
+        resolvedStyle: { ...nextData.style },
+        sheetName: activeSheet?.name ?? "",
+        value: nextData.value,
+        workbookSheetIndex: activeSheet?.workbookSheetIndex ?? -1
+      });
+      if (styleOverrides) {
+        nextData.style = { ...nextData.style, ...styleOverrides };
+      }
+    }
+
     nextData.canvas = buildCanvasCellStyleCache(nextData.style);
 
     if (canCellTextOverflow(nextData)) {
@@ -9059,6 +9081,7 @@ function XlsxGrid({
     displayDefaultColWidth,
     displayEffectiveColWidths,
     effectiveTables,
+    getCellStyle,
     palette,
     sparklinesByCell,
     viewportRowBatch,
@@ -14999,6 +15022,7 @@ function XlsxViewerInner({
   errorState,
   experimentalCanvas = true,
   fileTooLargeState,
+  getCellStyle,
   height,
   isDark = false,
   loadingComponent,
@@ -15071,6 +15095,7 @@ function XlsxViewerInner({
                 errorState={errorState}
                 experimentalCanvas={experimentalCanvas}
                 fileTooLargeState={fileTooLargeState}
+                getCellStyle={getCellStyle}
                 loadingComponent={loadingComponent}
                 loadingState={loadingState}
                 palette={palette}

--- a/packages/react-xlsx/src/index.ts
+++ b/packages/react-xlsx/src/index.ts
@@ -23,6 +23,7 @@ export type {
   XlsxChartSeries,
   XlsxCellAddress,
   XlsxCellRange,
+  XlsxCellStyleContext,
   XlsxFileTooLargeRenderProps,
   XlsxImage,
   XlsxImageAnchor,

--- a/packages/react-xlsx/src/types.ts
+++ b/packages/react-xlsx/src/types.ts
@@ -994,6 +994,35 @@ export interface XlsxTableHeaderMenuRenderProps {
   triggerProps: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
+export interface XlsxCellStyleContext {
+  /** Address of the cell being styled. */
+  cell: XlsxCellAddress;
+  /** True when the cell is part of a selected chart's highlighted source range. */
+  hasChartHighlight: boolean;
+  /** True when a conditional format (color scale, data bar, or icon set) applies to the cell. */
+  hasConditionalFormat: boolean;
+  /** True when the cell has a hyperlink. */
+  hasHyperlink: boolean;
+  /** True when the cell has a data validation rule. */
+  hasValidation: boolean;
+  /** True when the cell is the anchor of a merged range. */
+  isMerged: boolean;
+  /** True when the cell is a table header cell. */
+  isTableHeader: boolean;
+  /**
+   * The fully resolved style the viewer computed for this cell, combining the workbook's
+   * own formatting with the viewer's built-in styling. Treat this as read-only; returning
+   * a partial style from `getCellStyle` merges on top of it.
+   */
+  resolvedStyle: React.CSSProperties;
+  /** Display name of the sheet the cell belongs to. */
+  sheetName: string;
+  /** The cell's resolved display value. */
+  value: string;
+  /** Workbook sheet index of the cell's sheet. */
+  workbookSheetIndex: number;
+}
+
 export interface XlsxViewerProviderProps extends UseXlsxViewerControllerOptions {
   /** Viewer UI and hooks that should share this provider's workbook controller. */
   children: React.ReactNode;
@@ -1062,6 +1091,33 @@ export interface XlsxViewerProps extends UseXlsxViewerControllerOptions {
   errorState?: React.ReactNode | ((error: Error) => React.ReactNode);
   /** Content shown when `maxFileSizeBytes` rejects a file. */
   fileTooLargeState?: React.ReactNode | ((props: XlsxFileTooLargeRenderProps) => React.ReactNode);
+  /**
+   * Returns extra CSS style overrides for an individual cell. Called for every rendered cell
+   * with the cell's address, sheet, resolved style, and contextual flags. Return `undefined`
+   * (or `null`) to leave a cell untouched, or a partial style object that merges on top of the
+   * viewer's resolved style. Use this as an escape hatch for custom per-cell styling such as
+   * highlights, outlines, or status tints, without forking the workbook data.
+   *
+   * The DOM renderer applies every returned CSS property. The canvas renderer
+   * (`experimentalCanvas`, the default) honors the subset it can paint: `backgroundColor`,
+   * `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`,
+   * `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`,
+   * `outline`, or `animation` apply in the DOM renderer (`experimentalCanvas={false}`).
+   *
+   * Keep this callback stable (e.g. wrap it in `useCallback`) so cell styling is not recomputed
+   * on every render. When the callback identity changes, the viewer re-resolves and repaints
+   * cell styles.
+   *
+   * @example
+   * ```tsx
+   * const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+   *   ({ cell }) => (cell.row === 3 && cell.col === 1 ? { backgroundColor: "#dbeafe" } : undefined),
+   *   []
+   * );
+   * return <XlsxViewer file={buffer} getCellStyle={getCellStyle} />;
+   * ```
+   */
+  getCellStyle?: (context: XlsxCellStyleContext) => React.CSSProperties | null | undefined;
   /**
    * CSS height for the viewer container.
    *


### PR DESCRIPTION
## Summary

Adds an optional `getCellStyle` prop to `XlsxViewer` (and `XlsxViewerProps`) — a generic escape hatch for styling individual cells without forking the workbook data. It follows the same philosophy as the existing render-prop / color-override props (`renderImage`, `renderTableHeaderMenu`, `selectionColor`, etc.).

The viewer calls `getCellStyle` for every rendered cell and merges the returned partial `React.CSSProperties` on top of the cell's resolved style. Returning `undefined`/`null` leaves a cell untouched.

```tsx
const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
  ({ cell, isTableHeader }) =>
    !isTableHeader && highlighted.has(`${cell.row}:${cell.col}`)
      ? { backgroundColor: "rgba(37, 99, 235, 0.12)", outline: "1px solid #2563eb" }
      : undefined,
  [highlighted]
);

<XlsxViewer file={buffer} getCellStyle={getCellStyle} />;
```

### Why

Integrations often need to decorate specific cells (highlights, outlines, status tints) on top of the workbook's own formatting. Today that requires mutating workbook data or forking the renderer. `getCellStyle` provides a small, unopinionated hook for it.

## Implementation

- Applied at the single `getCellData` chokepoint that feeds **both** the DOM and canvas renderers, so styling works in either mode and the canvas style cache is built from the final merged style.
- Wired into the cell render cache invalidation and `getCellData` dependencies, so changing the callback identity re-resolves and repaints cells. The DOM row memo already re-renders on `getCellData` identity change.
- The callback receives an `XlsxCellStyleContext`: `cell`, `workbookSheetIndex`, `sheetName`, `resolvedStyle`, `value`, and flags (`hasValidation`, `hasHyperlink`, `hasConditionalFormat`, `hasChartHighlight`, `isMerged`, `isTableHeader`).

### Renderer parity

- DOM renderer (`experimentalCanvas={false}`) applies every returned CSS property.
- Canvas renderer (default) honors the subset it can paint: `backgroundColor`, `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`, `textDecoration`, `textOverflow`, and font properties. CSS-only effects (`boxShadow`, `outline`, `animation`) apply in the DOM renderer. This is documented.
- Not applied to worksheet thumbnails painted via `useXlsxViewerThumbnails(...)`.

## Changes

- `getCellStyle` prop + `XlsxCellStyleContext` type, exported from the package
- Wiring through `XlsxViewerInner` → `XlsxGrid` → `getCellData`
- Playground: a "Highlight" toggle demonstrating the prop live
- README docs (root + package) with the context table and renderer notes

## Test plan

- [x] `pnpm typecheck` (package + playground)
- [x] `pnpm build` (package) — `getCellStyle` and `XlsxCellStyleContext` present in `dist/index.d.ts`
- [ ] Toggle "Highlight" in the playground and confirm odd rows tint in both canvas and DOM renderers

Made with [Cursor](https://cursor.com)