### PR TITLE
Add cellStyleRevision prop for animated cell styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ export function WorkbookWorkspace({ buffer }: { buffer: ArrayBuffer }) {
 | Prop | Type | Notes |
 | --- | --- | --- |
 | `emptyState` | `React.ReactNode` | Rendered when no workbook is loaded. |
+| `getCellStyle` | `(context: XlsxCellStyleContext) => React.CSSProperties \| null \| undefined` | Returns extra CSS overrides merged on top of each cell's resolved style. Escape hatch for custom per-cell styling (highlights, outlines, status tints) without forking workbook data. See [Custom Cell Styling](#custom-cell-styling). |
 | `loadingComponent` | `React.ReactElement` | Full loading replacement component. |
 | `loadingState` | `React.ReactNode` | Loading fallback content. |
 | `errorState` | `React.ReactNode \| (error: Error) => React.ReactNode` | Custom error UI. |
@@ -162,6 +163,55 @@ Notes:
 - This render prop is intended for returning the full trigger and menu tree, not just menu items
 - In the default DOM renderer, your returned node replaces the built-in chevron trigger in the table header cell
 - `experimentalCanvas` still uses the built-in canvas affordance for table header menus
+
+## Custom Cell Styling
+
+`getCellStyle` is an escape hatch for styling individual cells without forking the workbook data. The viewer calls it for every rendered cell and merges the returned partial style on top of the cell's resolved style. Return `undefined` (or `null`) to leave a cell untouched.
+
+```tsx
+import * as React from "react";
+import { XlsxViewer, type XlsxViewerProps } from "@extend-ai/react-xlsx";
+
+function Workbook({ buffer, highlighted }: { buffer: ArrayBuffer; highlighted: Set<string> }) {
+  const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+    ({ cell, isTableHeader }) => {
+      if (isTableHeader) {
+        return undefined;
+      }
+      if (highlighted.has(`${cell.row}:${cell.col}`)) {
+        return { backgroundColor: "rgba(37, 99, 235, 0.12)", outline: "1px solid #2563eb" };
+      }
+      return undefined;
+    },
+    [highlighted]
+  );
+
+  return <XlsxViewer file={buffer} getCellStyle={getCellStyle} />;
+}
+```
+
+The `context` argument is an `XlsxCellStyleContext`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `cell` | `XlsxCellAddress` | Address of the cell being styled. |
+| `workbookSheetIndex` | `number` | Workbook sheet index of the cell's sheet. |
+| `sheetName` | `string` | Display name of the cell's sheet. |
+| `resolvedStyle` | `React.CSSProperties` | The style the viewer computed (workbook formatting + built-ins). Read-only. |
+| `value` | `string` | The cell's resolved display value. |
+| `hasValidation` | `boolean` | Cell has a data validation rule. |
+| `hasHyperlink` | `boolean` | Cell has a hyperlink. |
+| `hasConditionalFormat` | `boolean` | Cell is affected by a color scale, data bar, or icon set. |
+| `hasChartHighlight` | `boolean` | Cell is in a selected chart's highlighted source range. |
+| `isMerged` | `boolean` | Cell is the anchor of a merged range. |
+| `isTableHeader` | `boolean` | Cell is a table header cell. |
+
+Notes:
+
+- Keep the callback stable (e.g. wrap it in `useCallback`) so cell styling is not recomputed on every render. When the callback identity changes, the viewer re-resolves and repaints cells.
+- The DOM renderer (`experimentalCanvas={false}`) applies every returned CSS property.
+- The canvas renderer (the default) honors the subset it can paint: `backgroundColor`, `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`, `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`, `outline`, or `animation` apply in the DOM renderer.
+- `getCellStyle` is not applied to worksheet thumbnails painted via `useXlsxViewerThumbnails(...)`.
 
 ## `XlsxViewerProvider` Props
 
@@ -310,7 +360,7 @@ The package also exports the main types you are likely to use for custom integra
 - `XlsxImage`, `XlsxImageRect`, `XlsxImageRenderProps`, `XlsxImageSelectionRenderProps`
 - `XlsxSheetThumbnail`, `XlsxSheetThumbnailResolution`
 - `XlsxTable`, `XlsxTableColumn`, `XlsxTableHeaderMenuRenderProps`
-- `XlsxWorkbookTab`, `XlsxCellAddress`, `XlsxCellRange`
+- `XlsxWorkbookTab`, `XlsxCellAddress`, `XlsxCellRange`, `XlsxCellStyleContext`
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,47 @@ Notes:
 - The canvas renderer (the default) honors the subset it can paint: `backgroundColor`, `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`, `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`, `outline`, or `animation` apply in the DOM renderer.
 - `getCellStyle` is not applied to worksheet thumbnails painted via `useXlsxViewerThumbnails(...)`.
 
+### Animating Cell Styles
+
+To animate cell styling while keeping a stable `getCellStyle` callback, store transient styling state in a ref and bump the `cellStyleRevision` prop whenever the styles should change. Each new value forces the viewer to re-run `getCellStyle` and repaint.
+
+```tsx
+import * as React from "react";
+import { XlsxViewer, type XlsxViewerProps } from "@extend-ai/react-xlsx";
+
+function PulsingHighlight({ buffer }: { buffer: ArrayBuffer }) {
+  const pulseRef = React.useRef(0);
+  const [revision, setRevision] = React.useState(0);
+
+  React.useEffect(() => {
+    let frame = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      pulseRef.current = (Math.sin((now - start) / 800) + 1) / 2;
+      setRevision((value) => value + 1);
+      frame = window.requestAnimationFrame(tick);
+    };
+    frame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frame);
+  }, []);
+
+  const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+    ({ cell }) =>
+      cell.row === 2 && cell.col === 1
+        ? { backgroundColor: `rgba(37, 99, 235, ${(0.1 + pulseRef.current * 0.2).toFixed(3)})` }
+        : undefined,
+    []
+  );
+
+  return <XlsxViewer file={buffer} getCellStyle={getCellStyle} cellStyleRevision={revision} />;
+}
+```
+
+Notes:
+
+- `cellStyleRevision` is only needed when `getCellStyle` stays stable but its output changes over time. Changing the `getCellStyle` callback identity already re-resolves cells.
+- Animated `backgroundColor`, `color`, and border changes repaint in both renderers. CSS-only animations (keyframes, transitions) only run in the DOM renderer (`experimentalCanvas={false}`).
+
 ## `XlsxViewerProvider` Props
 
 `XlsxViewerProvider` accepts all `UseXlsxViewerControllerOptions` plus:

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -7,7 +7,8 @@ import {
   useXlsxViewerThumbnails,
   useXlsxViewerZoom,
   XlsxViewer,
-  XlsxViewerProvider
+  XlsxViewerProvider,
+  type XlsxViewerProps
 } from "@extend-ai/react-xlsx";
 import { Button } from "./components/ui/button";
 import { ButtonGroup } from "./components/ui/button-group";
@@ -93,6 +94,7 @@ function ViewerFileTooLargeState() {
 
 function WorkbookToolbar({
   experimentalCanvas,
+  highlightCells,
   isDocumentDark,
   onClear,
   onLoadExampleUrl,
@@ -101,11 +103,13 @@ function WorkbookToolbar({
   readOnly,
   remoteUrl,
   setExperimentalCanvas,
+  setHighlightCells,
   setIsDocumentDark,
   setReadOnly,
   setRemoteUrl,
 }: {
   experimentalCanvas: boolean;
+  highlightCells: boolean;
   isDocumentDark: boolean;
   onClear: () => void;
   onLoadExampleUrl: () => void;
@@ -114,6 +118,7 @@ function WorkbookToolbar({
   readOnly: boolean;
   remoteUrl: string;
   setExperimentalCanvas: (value: boolean) => void;
+  setHighlightCells: (value: boolean) => void;
   setIsDocumentDark: (value: boolean) => void;
   setReadOnly: (value: boolean) => void;
   setRemoteUrl: (value: string) => void;
@@ -237,6 +242,15 @@ function WorkbookToolbar({
               aria-label="Toggle read only mode"
               checked={isReadOnly}
               onCheckedChange={setReadOnly}
+              size="sm"
+            />
+          </div>
+          <div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
+            <span className="text-muted-foreground text-[11px] font-medium">Highlight</span>
+            <Switch
+              aria-label="Toggle custom cell highlighting via getCellStyle"
+              checked={highlightCells}
+              onCheckedChange={setHighlightCells}
               size="sm"
             />
           </div>
@@ -537,7 +551,21 @@ export function App() {
   const [isDocumentDark, setIsDocumentDark] = React.useState(false);
   const [experimentalCanvas, setExperimentalCanvas] = React.useState(true);
   const [isReadOnly, setIsReadOnly] = React.useState(true);
+  const [highlightCells, setHighlightCells] = React.useState(false);
   const dragDepthRef = React.useRef(0);
+
+  const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+    ({ cell, isTableHeader }) => {
+      if (!highlightCells || isTableHeader) {
+        return undefined;
+      }
+      if (cell.row % 2 === 1) {
+        return { backgroundColor: isDocumentDark ? "rgba(56, 189, 248, 0.16)" : "rgba(37, 99, 235, 0.08)" };
+      }
+      return undefined;
+    },
+    [highlightCells, isDocumentDark]
+  );
 
   const controller = useXlsxViewerController(
     source?.type === "file"
@@ -708,6 +736,7 @@ export function App() {
           <XlsxViewerProvider controller={controller} isDark={isDocumentDark}>
             <WorkbookToolbar
               experimentalCanvas={experimentalCanvas}
+              highlightCells={highlightCells}
               isDocumentDark={isDocumentDark}
               onClear={handleClear}
               onLoadExampleUrl={handleLoadExampleUrl}
@@ -716,6 +745,7 @@ export function App() {
               readOnly={isReadOnly}
               remoteUrl={remoteUrl}
               setExperimentalCanvas={setExperimentalCanvas}
+              setHighlightCells={setHighlightCells}
               setIsDocumentDark={setIsDocumentDark}
               setReadOnly={setIsReadOnly}
               setRemoteUrl={setRemoteUrl}
@@ -726,6 +756,7 @@ export function App() {
                   className="h-full min-h-0 min-w-0 flex-1"
                   emptyState={<ViewerEmptyState />}
                   fileTooLargeState={<ViewerFileTooLargeState />}
+                  getCellStyle={getCellStyle}
                   height="100%"
                   allowResizeInReadOnly
                   isDark={isDocumentDark}

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -93,6 +93,7 @@ function ViewerFileTooLargeState() {
 }
 
 function WorkbookToolbar({
+  animateHighlight,
   experimentalCanvas,
   highlightCells,
   isDocumentDark,
@@ -102,12 +103,14 @@ function WorkbookToolbar({
   onOpenFile,
   readOnly,
   remoteUrl,
+  setAnimateHighlight,
   setExperimentalCanvas,
   setHighlightCells,
   setIsDocumentDark,
   setReadOnly,
   setRemoteUrl,
 }: {
+  animateHighlight: boolean;
   experimentalCanvas: boolean;
   highlightCells: boolean;
   isDocumentDark: boolean;
@@ -117,6 +120,7 @@ function WorkbookToolbar({
   onOpenFile: () => void;
   readOnly: boolean;
   remoteUrl: string;
+  setAnimateHighlight: (value: boolean) => void;
   setExperimentalCanvas: (value: boolean) => void;
   setHighlightCells: (value: boolean) => void;
   setIsDocumentDark: (value: boolean) => void;
@@ -251,6 +255,16 @@ function WorkbookToolbar({
               aria-label="Toggle custom cell highlighting via getCellStyle"
               checked={highlightCells}
               onCheckedChange={setHighlightCells}
+              size="sm"
+            />
+          </div>
+          <div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
+            <span className="text-muted-foreground text-[11px] font-medium">Animate</span>
+            <Switch
+              aria-label="Animate cell highlighting via cellStyleRevision"
+              checked={animateHighlight}
+              disabled={!highlightCells}
+              onCheckedChange={setAnimateHighlight}
               size="sm"
             />
           </div>
@@ -552,19 +566,40 @@ export function App() {
   const [experimentalCanvas, setExperimentalCanvas] = React.useState(true);
   const [isReadOnly, setIsReadOnly] = React.useState(true);
   const [highlightCells, setHighlightCells] = React.useState(false);
+  const [animateHighlight, setAnimateHighlight] = React.useState(false);
+  const [cellStyleRevision, setCellStyleRevision] = React.useState(0);
+  const pulseRef = React.useRef(0);
   const dragDepthRef = React.useRef(0);
+
+  React.useEffect(() => {
+    if (!highlightCells || !animateHighlight) {
+      pulseRef.current = 0;
+      return;
+    }
+
+    let frame = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      // Oscillate between 0 and 1 on a ~1.6s loop, then flush via the revision counter.
+      pulseRef.current = (Math.sin((now - start) / 800) + 1) / 2;
+      setCellStyleRevision((value) => value + 1);
+      frame = window.requestAnimationFrame(tick);
+    };
+    frame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frame);
+  }, [animateHighlight, highlightCells]);
 
   const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
     ({ cell, isTableHeader }) => {
-      if (!highlightCells || isTableHeader) {
+      if (!highlightCells || isTableHeader || cell.row % 2 === 0) {
         return undefined;
       }
-      if (cell.row % 2 === 1) {
-        return { backgroundColor: isDocumentDark ? "rgba(56, 189, 248, 0.16)" : "rgba(37, 99, 235, 0.08)" };
-      }
-      return undefined;
+      const baseAlpha = isDocumentDark ? 0.16 : 0.08;
+      const alpha = animateHighlight ? baseAlpha + pulseRef.current * 0.18 : baseAlpha;
+      const channel = isDocumentDark ? "56, 189, 248" : "37, 99, 235";
+      return { backgroundColor: `rgba(${channel}, ${alpha.toFixed(3)})` };
     },
-    [highlightCells, isDocumentDark]
+    [animateHighlight, highlightCells, isDocumentDark]
   );
 
   const controller = useXlsxViewerController(
@@ -735,6 +770,7 @@ export function App() {
         >
           <XlsxViewerProvider controller={controller} isDark={isDocumentDark}>
             <WorkbookToolbar
+              animateHighlight={animateHighlight}
               experimentalCanvas={experimentalCanvas}
               highlightCells={highlightCells}
               isDocumentDark={isDocumentDark}
@@ -744,6 +780,7 @@ export function App() {
               onOpenFile={() => fileInputRef.current?.click()}
               readOnly={isReadOnly}
               remoteUrl={remoteUrl}
+              setAnimateHighlight={setAnimateHighlight}
               setExperimentalCanvas={setExperimentalCanvas}
               setHighlightCells={setHighlightCells}
               setIsDocumentDark={setIsDocumentDark}
@@ -755,6 +792,7 @@ export function App() {
                 <XlsxViewer
                   className="h-full min-h-0 min-w-0 flex-1"
                   emptyState={<ViewerEmptyState />}
+                  cellStyleRevision={cellStyleRevision}
                   fileTooLargeState={<ViewerFileTooLargeState />}
                   getCellStyle={getCellStyle}
                   height="100%"

--- a/packages/react-xlsx/README.md
+++ b/packages/react-xlsx/README.md
@@ -345,6 +345,7 @@ Common rendering props:
 - `errorState?: React.ReactNode | ((error: Error) => React.ReactNode)`
 - `fileTooLargeState?: React.ReactNode | ((props: XlsxFileTooLargeRenderProps) => React.ReactNode)`
 - `getCellStyle?: (context: XlsxCellStyleContext) => React.CSSProperties | null | undefined`
+- `cellStyleRevision?: number`
 - `renderImage?: (props: XlsxImageRenderProps) => React.ReactNode`
 - `renderImageSelection?: (props: XlsxImageSelectionRenderProps) => React.ReactNode`
 - `renderChartLoading?: (props: XlsxChartLoadingRenderProps) => React.ReactNode`
@@ -398,6 +399,35 @@ Notes:
 - The DOM renderer (`experimentalCanvas={false}`) applies every returned CSS property.
 - The canvas renderer (the default) honors the subset it can paint: `backgroundColor`, `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`, `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`, `outline`, or `animation` apply in the DOM renderer.
 - `getCellStyle` is not applied to worksheet thumbnails painted via `useXlsxViewerThumbnails(...)`.
+
+To animate cell styling while keeping a stable `getCellStyle` callback, store transient styling state in a ref and bump the `cellStyleRevision` prop whenever the styles should change. Each new value forces the viewer to re-run `getCellStyle` and repaint. This is only needed when the callback stays stable but its output changes over time; changing the callback identity already re-resolves cells.
+
+```tsx
+const pulseRef = React.useRef(0);
+const [revision, setRevision] = React.useState(0);
+
+React.useEffect(() => {
+  let frame = 0;
+  const start = performance.now();
+  const tick = (now: number) => {
+    pulseRef.current = (Math.sin((now - start) / 800) + 1) / 2;
+    setRevision((value) => value + 1);
+    frame = window.requestAnimationFrame(tick);
+  };
+  frame = window.requestAnimationFrame(tick);
+  return () => window.cancelAnimationFrame(frame);
+}, []);
+
+const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+  ({ cell }) =>
+    cell.row === 2 && cell.col === 1
+      ? { backgroundColor: `rgba(37, 99, 235, ${(0.1 + pulseRef.current * 0.2).toFixed(3)})` }
+      : undefined,
+  []
+);
+
+return <XlsxViewer file={buffer} getCellStyle={getCellStyle} cellStyleRevision={revision} />;
+```
 
 ### Custom Scroll Area
 

--- a/packages/react-xlsx/README.md
+++ b/packages/react-xlsx/README.md
@@ -344,11 +344,60 @@ Common rendering props:
 - `loadingState?: React.ReactNode`
 - `errorState?: React.ReactNode | ((error: Error) => React.ReactNode)`
 - `fileTooLargeState?: React.ReactNode | ((props: XlsxFileTooLargeRenderProps) => React.ReactNode)`
+- `getCellStyle?: (context: XlsxCellStyleContext) => React.CSSProperties | null | undefined`
 - `renderImage?: (props: XlsxImageRenderProps) => React.ReactNode`
 - `renderImageSelection?: (props: XlsxImageSelectionRenderProps) => React.ReactNode`
 - `renderChartLoading?: (props: XlsxChartLoadingRenderProps) => React.ReactNode`
 - `renderTableHeaderMenu?: (props: XlsxTableHeaderMenuRenderProps) => React.ReactNode`
 - `renderScroller?: (props: XlsxScrollerRenderProps) => React.ReactNode`
+
+### Custom Cell Styling
+
+`getCellStyle` is an escape hatch for styling individual cells without forking the workbook data. It is called for every rendered cell and returns a partial `React.CSSProperties` that merges on top of the viewer's resolved style. Return `undefined` (or `null`) to leave a cell untouched.
+
+```tsx
+import { XlsxViewer, type XlsxViewerProps } from "@extend-ai/react-xlsx";
+
+function Workbook({ buffer, highlighted }: { buffer: ArrayBuffer; highlighted: Set<string> }) {
+  const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+    ({ cell, isTableHeader }) => {
+      if (isTableHeader) {
+        return undefined;
+      }
+      if (highlighted.has(`${cell.row}:${cell.col}`)) {
+        return { backgroundColor: "rgba(37, 99, 235, 0.12)", outline: "1px solid #2563eb" };
+      }
+      return undefined;
+    },
+    [highlighted]
+  );
+
+  return <XlsxViewer file={buffer} getCellStyle={getCellStyle} />;
+}
+```
+
+The `context` passed to `getCellStyle` is an `XlsxCellStyleContext`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `cell` | `XlsxCellAddress` | Address of the cell being styled. |
+| `workbookSheetIndex` | `number` | Workbook sheet index of the cell's sheet. |
+| `sheetName` | `string` | Display name of the cell's sheet. |
+| `resolvedStyle` | `React.CSSProperties` | The style the viewer computed (workbook formatting + built-ins). Read-only. |
+| `value` | `string` | The cell's resolved display value. |
+| `hasValidation` | `boolean` | Cell has a data validation rule. |
+| `hasHyperlink` | `boolean` | Cell has a hyperlink. |
+| `hasConditionalFormat` | `boolean` | Cell is affected by a color scale, data bar, or icon set. |
+| `hasChartHighlight` | `boolean` | Cell is in a selected chart's highlighted source range. |
+| `isMerged` | `boolean` | Cell is the anchor of a merged range. |
+| `isTableHeader` | `boolean` | Cell is a table header cell. |
+
+Notes:
+
+- Keep the callback stable (e.g. `useCallback`) so cell styling is not recomputed every render. When the callback identity changes, the viewer re-resolves and repaints cells.
+- The DOM renderer (`experimentalCanvas={false}`) applies every returned CSS property.
+- The canvas renderer (the default) honors the subset it can paint: `backgroundColor`, `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`, `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`, `outline`, or `animation` apply in the DOM renderer.
+- `getCellStyle` is not applied to worksheet thumbnails painted via `useXlsxViewerThumbnails(...)`.
 
 ### Custom Scroll Area
 
@@ -415,6 +464,7 @@ The package exports the main types you are likely to use for custom integrations
 - `XlsxViewerCharts`
 - `XlsxViewerThumbnails`
 - `XlsxScrollerRenderProps`
+- `XlsxCellStyleContext`
 - `XlsxSheetThumbnail`
 - `UseXlsxViewerThumbnailsOptions`
 - `XlsxChart`, `XlsxChartSeries`, `XlsxChartAxis`, `XlsxChartsheet`

--- a/packages/react-xlsx/src/XlsxViewer.tsx
+++ b/packages/react-xlsx/src/XlsxViewer.tsx
@@ -6388,6 +6388,7 @@ const MemoGridRow = React.memo(GridRow, (prev, next) => {
 
 function XlsxGrid({
   allowResizeInReadOnly = false,
+  cellStyleRevision,
   controller,
   emptyState,
   enableCanvasSelectionAnimation = true,
@@ -6410,7 +6411,7 @@ function XlsxGrid({
   showImages = true
 }: Pick<
   XlsxViewerProps,
-  "allowResizeInReadOnly" | "emptyState" | "enableCanvasSelectionAnimation" | "enableGestureZoom" | "errorState" | "experimentalCanvas" | "fileTooLargeState" | "getCellStyle" | "loadingComponent" | "loadingState" | "renderChartLoading" | "renderImage" | "renderImageSelection" | "renderScroller" | "renderTableHeaderMenu" | "selectionColor" | "selectionFillColor" | "selectionHeaderColor" | "showImages"
+  "allowResizeInReadOnly" | "cellStyleRevision" | "emptyState" | "enableCanvasSelectionAnimation" | "enableGestureZoom" | "errorState" | "experimentalCanvas" | "fileTooLargeState" | "getCellStyle" | "loadingComponent" | "loadingState" | "renderChartLoading" | "renderImage" | "renderImageSelection" | "renderScroller" | "renderTableHeaderMenu" | "selectionColor" | "selectionFillColor" | "selectionHeaderColor" | "showImages"
 > & {
   controller: XlsxViewerController;
   palette: ViewerPalette;
@@ -8799,7 +8800,7 @@ function XlsxGrid({
 
   React.useEffect(() => {
     cellRenderCacheRef.current.clear();
-  }, [activeSheetIndex, displayColLimit, displayRowLimit, getCellStyle, palette, revision, viewportRowBatch, worksheet, zoomFactor]);
+  }, [activeSheetIndex, cellStyleRevision, displayColLimit, displayRowLimit, getCellStyle, palette, revision, viewportRowBatch, worksheet, zoomFactor]);
 
   React.useEffect(() => {
     setAsyncViewportRowBatch(null);
@@ -9076,6 +9077,10 @@ function XlsxGrid({
   }, [
     activeSheet,
     activeSheetChartHighlights,
+    // `cellStyleRevision` is intentionally a dependency: bumping it gives `getCellData` a new
+    // identity, which clears the cell render cache and repaints both the DOM and canvas renderers
+    // so a stable `getCellStyle` callback can return updated styles over time.
+    cellStyleRevision,
     colIndexByActual,
     colPrefixSums,
     displayDefaultColWidth,
@@ -15014,6 +15019,7 @@ function XlsxGrid({
 
 function XlsxViewerInner({
   allowResizeInReadOnly = false,
+  cellStyleRevision,
   className,
   controller,
   emptyState,
@@ -15088,6 +15094,7 @@ function XlsxViewerInner({
             <div style={{ display: "flex", flex: 1, minHeight: 0, minWidth: 0 }}>
               <XlsxGrid
                 allowResizeInReadOnly={allowResizeInReadOnly}
+                cellStyleRevision={cellStyleRevision}
                 controller={controller}
                 emptyState={emptyState}
                 enableCanvasSelectionAnimation={enableCanvasSelectionAnimation}

--- a/packages/react-xlsx/src/XlsxViewer.tsx
+++ b/packages/react-xlsx/src/XlsxViewer.tsx
@@ -6393,6 +6393,7 @@ function XlsxGrid({
   enableCanvasSelectionAnimation = true,
   errorState,
   fileTooLargeState,
+  getCellStyle,
   loadingComponent,
   loadingState,
   renderChartLoading,
@@ -6409,7 +6410,7 @@ function XlsxGrid({
   showImages = true
 }: Pick<
   XlsxViewerProps,
-  "allowResizeInReadOnly" | "emptyState" | "enableCanvasSelectionAnimation" | "enableGestureZoom" | "errorState" | "experimentalCanvas" | "fileTooLargeState" | "loadingComponent" | "loadingState" | "renderChartLoading" | "renderImage" | "renderImageSelection" | "renderScroller" | "renderTableHeaderMenu" | "selectionColor" | "selectionFillColor" | "selectionHeaderColor" | "showImages"
+  "allowResizeInReadOnly" | "emptyState" | "enableCanvasSelectionAnimation" | "enableGestureZoom" | "errorState" | "experimentalCanvas" | "fileTooLargeState" | "getCellStyle" | "loadingComponent" | "loadingState" | "renderChartLoading" | "renderImage" | "renderImageSelection" | "renderScroller" | "renderTableHeaderMenu" | "selectionColor" | "selectionFillColor" | "selectionHeaderColor" | "showImages"
 > & {
   controller: XlsxViewerController;
   palette: ViewerPalette;
@@ -8798,7 +8799,7 @@ function XlsxGrid({
 
   React.useEffect(() => {
     cellRenderCacheRef.current.clear();
-  }, [activeSheetIndex, displayColLimit, displayRowLimit, palette, revision, viewportRowBatch, worksheet, zoomFactor]);
+  }, [activeSheetIndex, displayColLimit, displayRowLimit, getCellStyle, palette, revision, viewportRowBatch, worksheet, zoomFactor]);
 
   React.useEffect(() => {
     setAsyncViewportRowBatch(null);
@@ -8965,6 +8966,27 @@ function XlsxGrid({
             : getCellDisplayValue(worksheet, row, col, activeSheet)
     };
 
+    if (getCellStyle) {
+      const styleOverrides = getCellStyle({
+        cell: { row, col },
+        hasChartHighlight: Boolean(nextData.chartHighlight),
+        hasConditionalFormat: Boolean(
+          nextData.conditionalColorScale || nextData.conditionalDataBar || nextData.conditionalIcon
+        ),
+        hasHyperlink: Boolean(nextData.hyperlink),
+        hasValidation: Boolean(nextData.validation),
+        isMerged: Boolean(nextData.colSpan || nextData.rowSpan),
+        isTableHeader: Boolean(nextData.isTableHeader),
+        resolvedStyle: { ...nextData.style },
+        sheetName: activeSheet?.name ?? "",
+        value: nextData.value,
+        workbookSheetIndex: activeSheet?.workbookSheetIndex ?? -1
+      });
+      if (styleOverrides) {
+        nextData.style = { ...nextData.style, ...styleOverrides };
+      }
+    }
+
     nextData.canvas = buildCanvasCellStyleCache(nextData.style);
 
     if (canCellTextOverflow(nextData)) {
@@ -9059,6 +9081,7 @@ function XlsxGrid({
     displayDefaultColWidth,
     displayEffectiveColWidths,
     effectiveTables,
+    getCellStyle,
     palette,
     sparklinesByCell,
     viewportRowBatch,
@@ -14999,6 +15022,7 @@ function XlsxViewerInner({
   errorState,
   experimentalCanvas = true,
   fileTooLargeState,
+  getCellStyle,
   height,
   isDark = false,
   loadingComponent,
@@ -15071,6 +15095,7 @@ function XlsxViewerInner({
                 errorState={errorState}
                 experimentalCanvas={experimentalCanvas}
                 fileTooLargeState={fileTooLargeState}
+                getCellStyle={getCellStyle}
                 loadingComponent={loadingComponent}
                 loadingState={loadingState}
                 palette={palette}

--- a/packages/react-xlsx/src/index.ts
+++ b/packages/react-xlsx/src/index.ts
@@ -23,6 +23,7 @@ export type {
   XlsxChartSeries,
   XlsxCellAddress,
   XlsxCellRange,
+  XlsxCellStyleContext,
   XlsxFileTooLargeRenderProps,
   XlsxImage,
   XlsxImageAnchor,

--- a/packages/react-xlsx/src/types.ts
+++ b/packages/react-xlsx/src/types.ts
@@ -1054,6 +1054,26 @@ export interface XlsxViewerProps extends UseXlsxViewerControllerOptions {
   /** Class name applied to the root viewer shell. */
   className?: string;
   /**
+   * Monotonic revision counter that forces the viewer to re-run `getCellStyle` and repaint cells
+   * when it changes. Use this to animate or refresh custom cell styling while keeping a stable
+   * `getCellStyle` callback: store transient styling state in a ref, update it (for example from a
+   * `requestAnimationFrame` loop or a timer), and bump this number to flush the new styles.
+   *
+   * Changing the `getCellStyle` callback identity already triggers a re-resolve, so this prop is
+   * only needed when the callback itself stays stable but its output should change over time.
+   *
+   * @example
+   * ```tsx
+   * const [styleRevision, setStyleRevision] = React.useState(0);
+   * React.useEffect(() => {
+   *   const id = window.setInterval(() => setStyleRevision((value) => value + 1), 16);
+   *   return () => window.clearInterval(id);
+   * }, []);
+   * return <XlsxViewer file={buffer} getCellStyle={getCellStyle} cellStyleRevision={styleRevision} />;
+   * ```
+   */
+  cellStyleRevision?: number;
+  /**
    * Existing controller to render. Takes precedence over provider context and source props on this viewer.
    *
    * @example

--- a/packages/react-xlsx/src/types.ts
+++ b/packages/react-xlsx/src/types.ts
@@ -994,6 +994,35 @@ export interface XlsxTableHeaderMenuRenderProps {
   triggerProps: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
+export interface XlsxCellStyleContext {
+  /** Address of the cell being styled. */
+  cell: XlsxCellAddress;
+  /** True when the cell is part of a selected chart's highlighted source range. */
+  hasChartHighlight: boolean;
+  /** True when a conditional format (color scale, data bar, or icon set) applies to the cell. */
+  hasConditionalFormat: boolean;
+  /** True when the cell has a hyperlink. */
+  hasHyperlink: boolean;
+  /** True when the cell has a data validation rule. */
+  hasValidation: boolean;
+  /** True when the cell is the anchor of a merged range. */
+  isMerged: boolean;
+  /** True when the cell is a table header cell. */
+  isTableHeader: boolean;
+  /**
+   * The fully resolved style the viewer computed for this cell, combining the workbook's
+   * own formatting with the viewer's built-in styling. Treat this as read-only; returning
+   * a partial style from `getCellStyle` merges on top of it.
+   */
+  resolvedStyle: React.CSSProperties;
+  /** Display name of the sheet the cell belongs to. */
+  sheetName: string;
+  /** The cell's resolved display value. */
+  value: string;
+  /** Workbook sheet index of the cell's sheet. */
+  workbookSheetIndex: number;
+}
+
 export interface XlsxViewerProviderProps extends UseXlsxViewerControllerOptions {
   /** Viewer UI and hooks that should share this provider's workbook controller. */
   children: React.ReactNode;
@@ -1062,6 +1091,33 @@ export interface XlsxViewerProps extends UseXlsxViewerControllerOptions {
   errorState?: React.ReactNode | ((error: Error) => React.ReactNode);
   /** Content shown when `maxFileSizeBytes` rejects a file. */
   fileTooLargeState?: React.ReactNode | ((props: XlsxFileTooLargeRenderProps) => React.ReactNode);
+  /**
+   * Returns extra CSS style overrides for an individual cell. Called for every rendered cell
+   * with the cell's address, sheet, resolved style, and contextual flags. Return `undefined`
+   * (or `null`) to leave a cell untouched, or a partial style object that merges on top of the
+   * viewer's resolved style. Use this as an escape hatch for custom per-cell styling such as
+   * highlights, outlines, or status tints, without forking the workbook data.
+   *
+   * The DOM renderer applies every returned CSS property. The canvas renderer
+   * (`experimentalCanvas`, the default) honors the subset it can paint: `backgroundColor`,
+   * `backgroundImage` gradients, `color`, the four `border*` sides, `padding`, `textAlign`,
+   * `textDecoration`, `textOverflow`, and font properties. CSS-only effects such as `boxShadow`,
+   * `outline`, or `animation` apply in the DOM renderer (`experimentalCanvas={false}`).
+   *
+   * Keep this callback stable (e.g. wrap it in `useCallback`) so cell styling is not recomputed
+   * on every render. When the callback identity changes, the viewer re-resolves and repaints
+   * cell styles.
+   *
+   * @example
+   * ```tsx
+   * const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
+   *   ({ cell }) => (cell.row === 3 && cell.col === 1 ? { backgroundColor: "#dbeafe" } : undefined),
+   *   []
+   * );
+   * return <XlsxViewer file={buffer} getCellStyle={getCellStyle} />;
+   * ```
+   */
+  getCellStyle?: (context: XlsxCellStyleContext) => React.CSSProperties | null | undefined;
   /**
    * CSS height for the viewer container.
    *


### PR DESCRIPTION
## Summary

Adds an optional `cellStyleRevision` prop to `XlsxViewer`. Bumping the counter forces the viewer to re-run `getCellStyle` and repaint cells, so consumers can **animate or refresh** custom cell styling while keeping a stable `getCellStyle` callback.

The pattern: store transient styling state in a ref, update it (e.g. from a `requestAnimationFrame` loop or timer), and bump `cellStyleRevision` to flush the new styles.

```tsx
const pulseRef = React.useRef(0);
const [revision, setRevision] = React.useState(0);

React.useEffect(() => {
  let frame = 0;
  const start = performance.now();
  const tick = (now: number) => {
    pulseRef.current = (Math.sin((now - start) / 800) + 1) / 2;
    setRevision((value) => value + 1);
    frame = window.requestAnimationFrame(tick);
  };
  frame = window.requestAnimationFrame(tick);
  return () => window.cancelAnimationFrame(frame);
}, []);

const getCellStyle = React.useCallback<NonNullable<XlsxViewerProps["getCellStyle"]>>(
  ({ cell }) =>
    cell.row === 2 && cell.col === 1
      ? { backgroundColor: `rgba(37, 99, 235, ${(0.1 + pulseRef.current * 0.2).toFixed(3)})` }
      : undefined,
  []
);

<XlsxViewer file={buffer} getCellStyle={getCellStyle} cellStyleRevision={revision} />;
```

### Why

`getCellStyle` (#8) re-resolves whenever the callback identity changes. For animation you'd otherwise have to recreate the callback every frame, which is non-obvious and creates churn. `cellStyleRevision` is an explicit, cheap animation primitive: keep the callback memoized and bump a number.

> [!NOTE]
> **Stacked on #8** (`getCellStyle`). Please review/merge that first — this PR's diff includes that commit until #8 lands, after which it will show only the `cellStyleRevision` commit. `cellStyleRevision` has no effect without `getCellStyle`.

## Implementation

- Wired into the same `getCellData` chokepoint and cache invalidation as `getCellStyle`, so a revision bump re-resolves styles and repaints **both** the DOM and canvas renderers.
- `cellStyleRevision` is intentionally a `getCellData` dependency (commented in code): a new value gives `getCellData` a new identity, which clears the cell render cache and triggers a canvas repaint and DOM row re-render.

## Changes

- `cellStyleRevision` prop on `XlsxViewerProps`
- Wiring through `XlsxViewerInner` → `XlsxGrid` → cache invalidation + `getCellData`
- Playground: an "Animate" toggle that pulses the highlight via a rAF loop + `cellStyleRevision`
- README docs (root + package) with the animation pattern and renderer notes

## Test plan

- [x] `pnpm typecheck` (package + playground)
- [x] `pnpm build` (package)
- [ ] Enable "Highlight" + "Animate" in the playground and confirm the tint pulses smoothly in both renderers

Made with [Cursor](https://cursor.com)