### PR TITLE
Fix crash editing chart workbooks: guard null layout node in data-label parsing

### DIFF
--- a/packages/react-xlsx/src/charts.ts
+++ b/packages/react-xlsx/src/charts.ts
@@ -1020,7 +1020,7 @@ function parseChartPointDataLabelsFromXml(labelsNode: Element): XlsxChartPointDa
     }
 
     const layoutNode = getFirstLocalChild(pointLabelNode, "layout");
-    const manualLayoutNode = getFirstLocalChild(layoutNode, "manualLayout");
+    const manualLayoutNode = layoutNode ? getFirstLocalChild(layoutNode, "manualLayout") : null;
     labels.push({
       deleted: readChartBooleanAttribute(pointLabelNode, "delete"),
       fontSizePt: readChartLabelFontSizePt(getFirstLocalChild(pointLabelNode, "txPr")) ?? fallbackFontSizePt,


### PR DESCRIPTION
## Summary

Editing a cell in a workbook that contains a chart throws an uncaught `TypeError` and breaks the grid:

```
Uncaught TypeError: Cannot read properties of null (reading 'childNodes')
    at getLocalChildren (charts.ts:2198)
    at getFirstLocalChild (charts.ts:2214)
    at parseChartPointDataLabelsFromXml (charts.ts:1023)
    at parseChartDataLabelsFromXml (charts.ts:1045)
    at applyChartStyleFromXml (charts.ts:1918)
    at loadWorkbookChartAssets (charts.ts:4004)
    at refreshWorkbookState (controller.tsx:2223)
    at setCellValue (controller.tsx:4067)
    at commitEditing (XlsxViewer.tsx:8787)
    at onKeyDown (XlsxViewer.tsx:14927)
```

A cell-edit commit re-parses the chart assets (`setCellValue` → `refreshWorkbookState` → `loadWorkbookChartAssets`), so this fires on **any** edit in a chart workbook — not just edits to the chart. And because it throws inside a DOM event handler, a React error boundary can't catch it. Initial load and a no-edit re-serialize (`saveXlsxBytes()` / `exportXlsx()`) are unaffected — only the post-edit re-parse hits it.

## Root cause

In `parseChartPointDataLabelsFromXml`:

```ts
const layoutNode = getFirstLocalChild(pointLabelNode, "layout");        // Element | null
const manualLayoutNode = getFirstLocalChild(layoutNode, "manualLayout"); // layoutNode may be null
```

For a `<c:dLbl>` with no `<c:layout>` child, `layoutNode` is `null`, and `getFirstLocalChild(null, …)` → `getLocalChildren(null, …)` dereferences `parent.childNodes`.

## Fix

Guard the layout node before descending, mirroring the existing null handling in `readChartNumericAttribute` / `readChartBooleanAttribute` (which both do `parent ? getFirstLocalChild(parent, …) : null`):

```ts
const manualLayoutNode = layoutNode ? getFirstLocalChild(layoutNode, "manualLayout") : null;
```

`manualLayoutNode` was already `Element | null` and its only consumer (`readChartNumericAttribute`) already handles `null`, so behavior is unchanged for workbooks that *do* have a layout node.

## Verification

- `pnpm --filter @extend-ai/react-xlsx typecheck` passes.
- Reproduced the crash on 0.13.1, then confirmed this change fixes it: editing and committing a cell in a 3-chart workbook no longer throws, the edit commits, and a full edit → save → reload round-trip holds.

Minimal standalone reproduction (editable viewer + in-page crash capture): https://github.com/tarungunampalli-rox/react-xlsx-chart-edit-crash-repro
