### PR TITLE
Add onWorkbookChange controller option for edit/persistence integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,24 @@ export function WorkbookWorkspace({ buffer }: { buffer: ArrayBuffer }) {
 | `useWorker` | `boolean` | Enables worker-backed parsing. Defaults to `true`. |
 | `deferLoadingAboveBytes` | `number` | Defers parsing above this byte threshold. Defaults to `0` (disabled). |
 | `maxFileSizeBytes` | `number` | Hard parse limit before rendering a too-large state. Defaults to `25 * 1024 * 1024` (`25 MB`). |
+| `onWorkbookChange` | `(revision: number) => void` | Called after any persisted workbook mutation (cell/style writes, paste, fill, merge, undo/redo, chart/image moves, sheet add/remove, named ranges). Not called during initial parsing or for view-only state like selection and zoom, so persistence integrations can react to it directly. |
 | `readOnly` | `boolean` | Forces viewer editing features off. Defaults to `false`. |
 | `readOnlyAboveBytes` | `number` | Automatically switches large workbooks into read-only mode above this threshold. Defaults to `0` (disabled). |
 | `skipXmlParsing` | `boolean` | Skips the OOXML ZIP/XML parsing layer and relies only on `Workbook.fromBytes(...)` metadata from `@dukelib/sheets-wasm`. The viewer also auto-enables this mode for legacy `.xls` files when their OLE magic bytes are detected. This is effectively the limited-support path used for `.xls` and some `.xlsm` content, so only data Duke Sheets can parse will render. Defaults to `false`. |
+
+Autosave example with `onWorkbookChange`:
+
+```tsx
+const controller = useXlsxViewerController({
+  file,
+  onWorkbookChange: () => {
+    const bytes = controller.workbook?.saveXlsxBytes();
+    if (bytes) {
+      persistDraft(bytes);
+    }
+  },
+});
+```
 
 ### Layout And Appearance Props
 

--- a/packages/react-xlsx/src/controller.tsx
+++ b/packages/react-xlsx/src/controller.tsx
@@ -1903,6 +1903,7 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     file,
     fileName,
     maxFileSizeBytes = DEFAULT_MAX_FILE_SIZE_BYTES,
+    onWorkbookChange,
     readOnly: requestedReadOnly = false,
     readOnlyAboveBytes = 0,
     showHiddenSheets = false,
@@ -1950,6 +1951,7 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
   const sheetOriginsRef = React.useRef<Array<WorkbookImageSheetOrigin | null>>([]);
   const workerClientRef = React.useRef<XlsxWorkerClient | null>(null);
   const workerCellSnapshotCacheRef = React.useRef(new Map<string, { displayValue: string; formula: string }>());
+  const notifiedRevisionRef = React.useRef<number | null>(null);
   const displayFileName = React.useMemo(() => resolveDisplayFileName(src, fileName), [fileName, src]);
   const shouldDeferLoading = deferLoadingAboveBytes > 0;
   const readOnly = requestedReadOnly || forcedReadOnly;
@@ -2236,6 +2238,24 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     revokeWorkbookImageAssets(imageAssetsRef.current);
     disposeWorkerClient();
   }, [disposeWorkerClient]);
+
+  // Revision also advances during parsing, so baseline it once loading settles
+  // and only report later bumps; clearing during loading re-baselines on swap.
+  React.useEffect(() => {
+    if (isLoading || isChartsLoading) {
+      notifiedRevisionRef.current = null;
+      return;
+    }
+    if (notifiedRevisionRef.current === null) {
+      notifiedRevisionRef.current = revision;
+      return;
+    }
+    if (revision === notifiedRevisionRef.current) {
+      return;
+    }
+    notifiedRevisionRef.current = revision;
+    onWorkbookChange?.(revision);
+  }, [isChartsLoading, isLoading, onWorkbookChange, revision]);
 
   React.useEffect(() => {
     if (!file && !src) {

--- a/packages/react-xlsx/src/types.ts
+++ b/packages/react-xlsx/src/types.ts
@@ -837,6 +837,18 @@ export interface UseXlsxViewerControllerOptions {
    */
   maxFileSizeBytes?: number;
   /**
+   * Called after any persisted workbook mutation: cell value/formula/style writes,
+   * paste, fill, merge, undo/redo, chart/image geometry changes, sheet add/remove,
+   * and named-range definitions. Not called while the workbook (or its charts) is
+   * still parsing, nor for view-only state such as selection, zoom, or sheet
+   * switches — so persistence integrations can act on it (e.g. export and save
+   * bytes) without filtering out load-time refreshes themselves.
+   *
+   * Receives the controller's current `revision`. The callback's identity does
+   * not need to be stable: changing it never re-reports an already-seen revision.
+   */
+  onWorkbookChange?: (revision: number) => void;
+  /**
    * Disables workbook edits, paste, fill, undo/redo, and other mutation actions.
    *
    * @default false


### PR DESCRIPTION
## Summary

Implements the `onWorkbookChange` callback proposed in #13 — an opt-in change notification for consumers embedding the viewer as an editor with autosave/persistence.

```ts
useXlsxViewerController({
  file,
  onWorkbookChange: (revision) => persistDraft(controller.workbook?.saveXlsxBytes()),
});
```

## Why

Today the only edit signal is watching `controller.revision` from an effect, and every consumer has to rediscover the same two subtleties:

- `revision` also advances while the workbook (and its charts) parses, so naive watchers persist a no-op save on open;
- it resets to `0` on a workbook swap.

Intercepting the `useXlsxViewerEditing` mutators is not an alternative: the grid's internal keyboard commit path calls `controller.setCellValue` directly, so wrapped mutators never see typing.

## What it does

- New optional `onWorkbookChange?: (revision: number) => void` on `UseXlsxViewerControllerOptions` (inherited by `XlsxViewerProps` / `XlsxViewerProviderProps`).
- Fires on exactly the persisted mutations that bump `revision`: cell value/formula/style writes, paste, fill, merge, undo/redo, chart/image geometry changes, sheet add/remove, named ranges. Never fires for selection/zoom/sheet-switch or during parsing.
- Load baselining is handled internally: the effect ignores bumps while `isLoading`/`isChartsLoading`, baselines the first settled revision, and clears the baseline during loading so a workbook swap re-baselines instead of firing.
- The callback's identity does not need to be stable: it is read as a plain effect dependency, and an identity change never re-reports an already-seen revision.

No behavior change for consumers that don't pass the option.

## Validation

- `pnpm --filter @extend-ai/react-xlsx typecheck` and `build` pass.
- We ship this exact baselining logic in production today (app-side, watching `controller.revision`) driving a debounced, version-locked autosave on `@extend-ai/react-xlsx@0.12.3`/`0.13.x` — same integration where we found and fixed the chart-edit crash in #12. This PR moves that logic where every consumer gets it for free.
- README: new row in the props table + an autosave example.

Closes #13
