### PR TITLE
feat: expose persistence-safe XLSX serialization and mutation events

### DIFF
--- a/packages/react-xlsx/README.md
+++ b/packages/react-xlsx/README.md
@@ -218,6 +218,45 @@ export function ControlledWorkbook({ file }: { file: ArrayBuffer }) {
 }
 ```
 
+### Persisting workbook changes
+
+Use `onMutation` to mark a hydrated workbook dirty, then call
+`serializeXlsx()` to obtain the same sanitized, asset-merged bytes used by the
+built-in XLSX export:
+
+```tsx
+import * as React from "react";
+import { XlsxViewer, useXlsxViewerController } from "@extend-ai/react-xlsx";
+
+export function PersistedWorkbook({ file }: { file: ArrayBuffer }) {
+  const [dirtyRevision, setDirtyRevision] = React.useState<number | null>(null);
+  const controller = useXlsxViewerController({
+    file,
+    onMutation: ({ revision }) => setDirtyRevision(revision),
+  });
+
+  const save = async () => {
+    const bytes = await controller.serializeXlsx();
+    await persistWorkbook(bytes, dirtyRevision);
+    setDirtyRevision(null);
+  };
+
+  return (
+    <>
+      <button type="button" onClick={save} disabled={dirtyRevision === null}>
+        Save
+      </button>
+      <XlsxViewer controller={controller} height={640} />
+    </>
+  );
+}
+```
+
+Initial workbook/chart hydration, selection, zoom, and other view-only changes
+do not call `onMutation`. Mutations made while chart assets are still hydrating
+are delivered once hydration completes. `serializeXlsx()` rejects until a
+workbook is ready.
+
 ## Useful Hooks
 
 These hooks work inside `XlsxViewer` or `XlsxViewerProvider` context.

--- a/packages/react-xlsx/package.json
+++ b/packages/react-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extend-ai/react-xlsx",
-  "version": "0.16.2",
+  "version": "0.16.2-erstan.1",
   "description": "React components and hooks for viewing XLSX workbooks",
   "license": "MIT",
   "keywords": [
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../scripts/copy-duke-wasm.mjs",
-    "test": "node --experimental-strip-types --test src/cell-text-clip.test.ts src/zip-entry-names.test.ts src/viewer-palette.test.ts",
+    "test": "node --experimental-strip-types --test src/cell-text-clip.test.ts src/persistence.test.ts src/zip-entry-names.test.ts src/viewer-palette.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/react-xlsx/src/controller.tsx
+++ b/packages/react-xlsx/src/controller.tsx
@@ -11,7 +11,6 @@ import type {
   ImageDrawing as DukeImageDrawing,
   Workbook
 } from "@dukelib/sheets-wasm";
-import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
 import {
   applyChartSeriesFormula,
   buildChartSeriesFormula,
@@ -45,6 +44,13 @@ import {
   type WorkbookImageAssets,
   type WorkbookImageSheetOrigin
 } from "./images";
+import {
+  advanceMutationNotificationState,
+  cloneBytes,
+  createMutationNotificationState,
+  createSavedWorkbookBytes as createPersistedWorkbookBytes,
+  type MutationNotificationState
+} from "./persistence";
 import { safeCalculate, tryRecalculate } from "./safe-calculate";
 import { canUseConfiguredWasmSourceInWorker, getSheetsWasmModule } from "./wasm";
 import { XlsxWorkerClient } from "./worker-client";
@@ -1233,29 +1239,6 @@ function decodeHtmlEntities(value: string): string {
     .replace(/&amp;/g, "&");
 }
 
-function cloneBytes(bytes: Uint8Array): Uint8Array {
-  const nextBytes = new Uint8Array(bytes.byteLength);
-  nextBytes.set(bytes);
-  return nextBytes;
-}
-
-function sanitizeSavedWorkbookBytes(bytes: Uint8Array): Uint8Array {
-  try {
-    const archive = unzipSync(bytes);
-    const stylesEntry = archive["xl/styles.xml"];
-    if (stylesEntry) {
-      const stylesXml = strFromU8(stylesEntry)
-        .replace(/&amp;quot;/g, "&quot;")
-        .replace(/&amp;apos;/g, "&apos;");
-      archive["xl/styles.xml"] = strToU8(stylesXml);
-    }
-
-    return zipSync(archive, { level: 6 });
-  } catch {
-    return cloneBytes(bytes);
-  }
-}
-
 function pushHistoryEntry(stack: HistoryEntry[], entry: HistoryEntry) {
   stack.push(entry);
   if (stack.length > HISTORY_LIMIT) {
@@ -1832,6 +1815,7 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     file,
     fileName,
     maxFileSizeBytes = DEFAULT_MAX_FILE_SIZE_BYTES,
+    onMutation,
     readOnly: requestedReadOnly = false,
     readOnlyAboveBytes = 0,
     showHiddenSheets = false,
@@ -1878,6 +1862,9 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
   const chartDisplayFallbackCleanupRef = React.useRef<(() => void) | null>(null);
   const sheetOriginsRef = React.useRef<Array<WorkbookImageSheetOrigin | null>>([]);
   const workerClientRef = React.useRef<XlsxWorkerClient | null>(null);
+  const mutationNotificationStateRef = React.useRef<MutationNotificationState>(
+    createMutationNotificationState()
+  );
   const workerCellSnapshotCacheRef = React.useRef(new Map<string, { displayValue: string; formula: string }>());
   const displayFileName = React.useMemo(() => resolveDisplayFileName(src, fileName), [fileName, src]);
   const shouldDeferLoading = deferLoadingAboveBytes > 0;
@@ -2175,6 +2162,22 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
     revokeWorkbookImageAssets(imageAssetsRef.current);
     disposeWorkerClient();
   }, [disposeWorkerClient]);
+
+  React.useEffect(() => {
+    const transition = advanceMutationNotificationState(
+      mutationNotificationStateRef.current,
+      {
+        hasWorkbook: Boolean(workbook),
+        isChartsLoading,
+        isLoading,
+        revision
+      }
+    );
+    mutationNotificationStateRef.current = transition.state;
+    if (transition.notificationRevision !== null) {
+      onMutation?.({ revision: transition.notificationRevision });
+    }
+  }, [isChartsLoading, isLoading, onMutation, revision, workbook]);
 
   React.useEffect(() => {
     if (!file && !src) {
@@ -3244,9 +3247,23 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
   const canRedo = !readOnly && redoStackRef.current.length > 0;
 
   const createSavedWorkbookBytes = React.useCallback((targetWorkbook: Workbook) => {
-    const sanitizedBytes = sanitizeSavedWorkbookBytes(targetWorkbook.saveXlsxBytes());
-    return mergeWorkbookImageAssets(sanitizedBytes, imageAssetsRef.current, sheetOriginsRef.current);
+    return createPersistedWorkbookBytes(
+      targetWorkbook,
+      (savedBytes) => mergeWorkbookImageAssets(
+        savedBytes,
+        imageAssetsRef.current,
+        sheetOriginsRef.current
+      )
+    );
   }, []);
+
+  const serializeXlsx = React.useCallback(async (): Promise<Uint8Array> => {
+    if (!workbook) {
+      throw new Error("Workbook is not ready.");
+    }
+
+    return createSavedWorkbookBytes(workbook);
+  }, [createSavedWorkbookBytes, workbook]);
 
   const createHistoryEntry = React.useCallback((): SnapshotHistoryEntry | null => {
     if (!workbook) {
@@ -4954,6 +4971,7 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
       redo,
       resetZoom,
       revision,
+      serializeXlsx,
       resizeChartBy,
       resizeImageBy,
       resizeColumn,
@@ -5072,6 +5090,7 @@ export function useXlsxViewerController(options: UseXlsxViewerControllerOptions)
       recalculate,
       redo,
       revision,
+      serializeXlsx,
       resizeChartBy,
       resizeImageBy,
       resizeColumn,

--- a/packages/react-xlsx/src/index.ts
+++ b/packages/react-xlsx/src/index.ts
@@ -57,6 +57,7 @@ export type {
   XlsxImageRenderProps,
   XlsxImageResizeHandlePosition,
   XlsxImageSelectionRenderProps,
+  XlsxMutationEvent,
   XlsxScrollerRenderProps,
   XlsxShape,
   XlsxShapeFill,

--- a/packages/react-xlsx/src/persistence.test.ts
+++ b/packages/react-xlsx/src/persistence.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Workbook } from "@dukelib/sheets-wasm";
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+import {
+  advanceMutationNotificationState,
+  createMutationNotificationState,
+  createSavedWorkbookBytes,
+  type MutationNotificationState
+} from "./persistence.ts";
+
+test("mutation notifications baseline hydration and emit later revisions once", () => {
+  let state = createMutationNotificationState();
+
+  let transition = advanceMutationNotificationState(state, {
+    hasWorkbook: false,
+    isChartsLoading: false,
+    isLoading: true,
+    revision: 0
+  });
+  assert.equal(transition.notificationRevision, null);
+  state = transition.state;
+
+  transition = advanceMutationNotificationState(state, {
+    hasWorkbook: true,
+    isChartsLoading: true,
+    isLoading: false,
+    revision: 0
+  });
+  assert.equal(transition.notificationRevision, null);
+  assert.deepEqual(transition.state, {
+    baselineRevision: 0,
+    pendingRevision: null
+  });
+  state = transition.state;
+
+  transition = advanceMutationNotificationState(state, {
+    hasWorkbook: true,
+    isChartsLoading: true,
+    isLoading: false,
+    revision: 1
+  });
+  assert.equal(transition.notificationRevision, null);
+  assert.deepEqual(transition.state, {
+    baselineRevision: 1,
+    pendingRevision: 1
+  });
+  state = transition.state;
+
+  transition = advanceMutationNotificationState(state, {
+    hasWorkbook: true,
+    isChartsLoading: false,
+    isLoading: false,
+    revision: 1
+  });
+  assert.equal(transition.notificationRevision, 1);
+  state = transition.state;
+
+  transition = advanceMutationNotificationState(state, {
+    hasWorkbook: true,
+    isChartsLoading: false,
+    isLoading: false,
+    revision: 1
+  });
+  assert.equal(transition.notificationRevision, null);
+  state = transition.state;
+
+  transition = advanceMutationNotificationState(state, {
+    hasWorkbook: true,
+    isChartsLoading: false,
+    isLoading: false,
+    revision: 2
+  });
+  assert.equal(transition.notificationRevision, 2);
+});
+
+test("mutation notifications reset and re-baseline when the workbook changes", () => {
+  let state: MutationNotificationState = {
+    baselineRevision: 4,
+    pendingRevision: null
+  };
+
+  let transition = advanceMutationNotificationState(state, {
+    hasWorkbook: true,
+    isChartsLoading: false,
+    isLoading: true,
+    revision: 4
+  });
+  assert.equal(transition.notificationRevision, null);
+  assert.deepEqual(transition.state, createMutationNotificationState());
+  state = transition.state;
+
+  transition = advanceMutationNotificationState(state, {
+    hasWorkbook: true,
+    isChartsLoading: false,
+    isLoading: false,
+    revision: 0
+  });
+  assert.equal(transition.notificationRevision, null);
+  assert.deepEqual(transition.state, {
+    baselineRevision: 0,
+    pendingRevision: null
+  });
+});
+
+test("saved workbook bytes use the sanitizing persistence pipeline", () => {
+  const sourceBytes = zipSync({
+    "[Content_Types].xml": strToU8("<Types />"),
+    "xl/styles.xml": strToU8("<style>&amp;quot;quoted&amp;quot; &amp;apos;value&amp;apos;</style>"),
+    "xl/worksheets/sheet1.xml": strToU8("<worksheet />")
+  });
+  let saveCalls = 0;
+  const workbook = {
+    saveXlsxBytes() {
+      saveCalls += 1;
+      return sourceBytes;
+    }
+  } as unknown as Workbook;
+
+  let mergeCalls = 0;
+  const savedBytes = createSavedWorkbookBytes(workbook, (sanitizedBytes) => {
+    mergeCalls += 1;
+    return new Uint8Array(sanitizedBytes);
+  });
+  const archive = unzipSync(savedBytes);
+
+  assert.equal(saveCalls, 1);
+  assert.equal(mergeCalls, 1);
+  assert.notEqual(savedBytes, sourceBytes);
+  assert.equal(
+    strFromU8(archive["xl/styles.xml"]),
+    "<style>&quot;quoted&quot; &apos;value&apos;</style>"
+  );
+  assert.equal(strFromU8(archive["xl/worksheets/sheet1.xml"]), "<worksheet />");
+  assert.equal(
+    strFromU8(unzipSync(sourceBytes)["xl/styles.xml"]),
+    "<style>&amp;quot;quoted&amp;quot; &amp;apos;value&amp;apos;</style>"
+  );
+});

--- a/packages/react-xlsx/src/persistence.ts
+++ b/packages/react-xlsx/src/persistence.ts
@@ -1,0 +1,118 @@
+import type { Workbook } from "@dukelib/sheets-wasm";
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+
+export interface MutationNotificationState {
+  baselineRevision: number | null;
+  pendingRevision: number | null;
+}
+
+export interface MutationNotificationTransition {
+  notificationRevision: number | null;
+  state: MutationNotificationState;
+}
+
+export function createMutationNotificationState(): MutationNotificationState {
+  return {
+    baselineRevision: null,
+    pendingRevision: null
+  };
+}
+
+/**
+ * Baselines controller refreshes during workbook loading and emits only later
+ * revisions. Mutations made while chart assets hydrate are queued and emitted
+ * once hydration completes so an early edit cannot be lost.
+ */
+export function advanceMutationNotificationState(
+  current: MutationNotificationState,
+  input: {
+    hasWorkbook: boolean;
+    isChartsLoading: boolean;
+    isLoading: boolean;
+    revision: number;
+  }
+): MutationNotificationTransition {
+  if (input.isLoading || !input.hasWorkbook) {
+    return {
+      notificationRevision: null,
+      state: createMutationNotificationState()
+    };
+  }
+
+  if (current.baselineRevision === null) {
+    return {
+      notificationRevision: null,
+      state: {
+        baselineRevision: input.revision,
+        pendingRevision: null
+      }
+    };
+  }
+
+  if (current.baselineRevision !== input.revision) {
+    if (input.isChartsLoading) {
+      return {
+        notificationRevision: null,
+        state: {
+          baselineRevision: input.revision,
+          pendingRevision: input.revision
+        }
+      };
+    }
+
+    return {
+      notificationRevision: input.revision,
+      state: {
+        baselineRevision: input.revision,
+        pendingRevision: null
+      }
+    };
+  }
+
+  if (!input.isChartsLoading && current.pendingRevision !== null) {
+    return {
+      notificationRevision: current.pendingRevision,
+      state: {
+        baselineRevision: current.baselineRevision,
+        pendingRevision: null
+      }
+    };
+  }
+
+  return {
+    notificationRevision: null,
+    state: current
+  };
+}
+
+export function cloneBytes(bytes: Uint8Array): Uint8Array {
+  const nextBytes = new Uint8Array(bytes.byteLength);
+  nextBytes.set(bytes);
+  return nextBytes;
+}
+
+function sanitizeSavedWorkbookBytes(bytes: Uint8Array): Uint8Array {
+  try {
+    const archive = unzipSync(bytes);
+    const stylesEntry = archive["xl/styles.xml"];
+    if (stylesEntry) {
+      const stylesXml = strFromU8(stylesEntry)
+        .replace(/&amp;quot;/g, "&quot;")
+        .replace(/&amp;apos;/g, "&apos;");
+      archive["xl/styles.xml"] = strToU8(stylesXml);
+    }
+
+    return zipSync(archive, { level: 6 });
+  } catch {
+    return cloneBytes(bytes);
+  }
+}
+
+/** The single XLSX serialization path used by history, download, and persistence. */
+export function createSavedWorkbookBytes(
+  targetWorkbook: Workbook,
+  mergeAssets: (savedBytes: Uint8Array) => Uint8Array
+): Uint8Array {
+  const sanitizedBytes = sanitizeSavedWorkbookBytes(targetWorkbook.saveXlsxBytes());
+  return mergeAssets(sanitizedBytes);
+}

--- a/packages/react-xlsx/src/types.ts
+++ b/packages/react-xlsx/src/types.ts
@@ -616,6 +616,12 @@ export interface XlsxFormControlChangeEvent {
   type: "change";
 }
 
+/** A persisted workbook mutation observed after initial workbook hydration. */
+export interface XlsxMutationEvent {
+  /** The controller revision containing the mutation. */
+  revision: number;
+}
+
 export interface XlsxFormControlRenderProps {
   /** Activates a button control. No-ops in read-only mode. */
   activate: () => void;
@@ -972,6 +978,12 @@ export interface UseXlsxViewerControllerOptions {
    */
   maxFileSizeBytes?: number;
   /**
+   * Called after a persisted workbook mutation. Initial workbook and chart
+   * hydration, selection, zoom, and other view-only changes do not notify.
+   * Mutations made while chart assets hydrate are delivered after hydration.
+   */
+  onMutation?: (event: XlsxMutationEvent) => void;
+  /**
    * Disables workbook edits, paste, fill, undo/redo, and other mutation actions.
    *
    * @default false
@@ -1084,6 +1096,11 @@ export interface XlsxViewerController {
   readOnly: boolean;
   recalculate: () => void;
   revision: number;
+  /**
+   * Serializes the current workbook through the same sanitization and
+   * image/chart asset merge path used by `exportXlsx()`.
+   */
+  serializeXlsx: () => Promise<Uint8Array>;
   resetZoom: () => void;
   resizeChartBy: (
     id: string,


### PR DESCRIPTION
## Summary

- exposes `controller.serializeXlsx()` through the same sanitization and image/chart asset-merge path used by `exportXlsx()`
- adds a typed `onMutation({ revision })` callback with hydration baselining and queued chart-hydration mutations
- re-baselines on workbook replacement and ignores view-only state changes
- documents the persistence integration and exports `XlsxMutationEvent`

## Why

Embedding applications need faithful bytes for versioned server persistence without triggering a browser download, plus a reliable post-hydration dirty signal. Calling Duke `saveXlsxBytes()` directly bypasses React XLSX's asset merge/sanitization path.

## Validation

- 15 focused persistence/mutation tests pass
- package and playground typechecks pass
- ESM, CJS, declaration, worker, and WASM build passes
- packed artifact installs/imports in a clean npm project

No Duke/WASM/formula/file-format core code is changed.